### PR TITLE
Replace regex with plain string functions to support older compilers

### DIFF
--- a/include/StringUtilities.h
+++ b/include/StringUtilities.h
@@ -5,7 +5,6 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
-#include <regex>
 #include <vector>
 #include <cstddef>
 

--- a/source/StringUtilities.cpp
+++ b/source/StringUtilities.cpp
@@ -47,6 +47,14 @@ namespace StringUtilities
         return os.str();
     }
     
+
+    void print( std::vector <std::string> & vector )
+    {
+        for (size_t n = 0; n < vector.size(); n++)
+            std::cout << "\"" << vector[ n ] << "\"" << std::endl;
+        std::cout << std::endl;
+    }
+
     
     /**
      * @brief      Replace the ENV['var'] pattern with the value of the environment variable 'var'.
@@ -72,53 +80,102 @@ namespace StringUtilities
      */
     string replaceEnvironmentVariable(const string inputString)
     {
-        const regex re(R"(ENV\['([A-Z_]+)'\])");
-        smatch match;
         string outputString;
-        
-        // Check if we have a match, i.e. if inputString contains the required pattern
-
-        regex_search(inputString, match, re);
-
-        if (match.empty())
-            return inputString;
+        string preMatch;       // contains the part of inputString before ENV['var']
+        string match;          // contains the var in ENV['var']
+        string postMatch;      // contains the part of inputString after ENV['var']
     
-        if (match.size() != 2)
+        const string prefix("ENV['");
+        const string suffix("']");
+    
+        string::size_type idx_prefix = inputString.find(prefix);
+        string::size_type idx_suffix = inputString.find(suffix);
+    
+        if (idx_prefix == string::npos)
         {
-            Log.warning("replaceEnvironmentVariable: expected one match for an environment variable, got " + to_string(match.size()-1) + " matches.");
-            return inputString;
+            // inputString does not contain an environment variable
+            
+            outputString = inputString;
+        }
+        else
+        {
+            if (idx_suffix == string::npos)
+            {
+                // inputString does not contain the closing part of the ENV['var'] pattern
+    
+                Log.warning("replaceEnvironmentVariable: closing part of the ENV['var'] pattern is not present, returning original string.\n"
+                    "inputString: " + inputString);
+    
+                outputString = inputString;
+            }
+            preMatch = inputString.substr(0, idx_prefix);
+            match = inputString.substr(idx_prefix + prefix.size(), idx_suffix - (idx_prefix + prefix.size()));
+            postMatch = inputString.substr(idx_suffix + suffix.size());
+    
+            // getenv will return a NULL when the environment variable doesn't exist
+            // We need to catch this before trying to convert to string (as the
+            // conversion will call strlen which will crash on NULL).
+            
+            const char * result = getenv(match.c_str());
+            if (!result)
+            {
+                Log.warning("replaceEnvironmentVariable: Environment variable " + match + " doesn't exist.");
+                return inputString;
+            }
+    
+            string envReplacement = string(result);
+    
+            outputString = preMatch + envReplacement + postMatch;
         }
     
-        // match[0] will contain the complete match including ENV[' and ']
-        // match[1] will contain only the name of the environment variable
     
-        string envName = match[1];
-    
-        // getenv will return a NULL when the environment variable doesn't exist
-        // We need to catch this before trying to convert to string (as the
-        // conversion will call strlen which will crash on NULL).
-        
-        const char * result = getenv(envName.c_str());
-        if (!result)
-        {
-            Log.warning("replaceEnvironmentVariable: Environment variable " + envName + " doesn't exist.");
-            return inputString;
-        }
-    
-        string envReplacement = string(result);
-    
-        outputString = regex_replace(inputString, re, envReplacement);
-        
         return outputString;
     }
 
-    
-    void print( std::vector <std::string> & vector )
-    {
-        for (size_t n = 0; n < vector.size(); n++)
-            std::cout << "\"" << vector[ n ] << "\"" << std::endl;
-        std::cout << std::endl;
-    }
-}
 
+//  This is the implementation of replaceEnvironmentVariable using regular expressions,
+//  but the code failed on GCC v4.8.5. This only works as off GCC v4.9.2.
+// 
+//  string replaceEnvironmentVariable(const string inputString)
+//  {
+//      const regex re(R"(ENV\['([A-Z_]+)'\])");
+//      smatch match;
+//      string outputString;
+//      
+//      // Check if we have a match, i.e. if inputString contains the required pattern
+///      regex_search(inputString, match, re);
+///      if (match.empty())
+//          return inputString;
+//  
+//      if (match.size() != 2)
+//      {
+//          Log.warning("replaceEnvironmentVariable: expected one match for an environment variable, got " + to_string(match.size()-1) + " matches.");
+//          return inputString;
+//      }
+//  
+//      // match[0] will contain the complete match including ENV[' and ']
+//      // match[1] will contain only the name of the environment variable
+//  
+//      string envName = match[1];
+//  
+//      // getenv will return a NULL when the environment variable doesn't exist
+//      // We need to catch this before trying to convert to string (as the
+//      // conversion will call strlen which will crash on NULL).
+//      
+//      const char * result = getenv(envName.c_str());
+//      if (!result)
+//      {
+//          Log.warning("replaceEnvironmentVariable: Environment variable " + envName + " doesn't exist.");
+//          return inputString;
+//      }
+//  
+//      string envReplacement = string(result);
+//  
+//      outputString = regex_replace(inputString, re, envReplacement);
+//      
+//      return outputString;
+//  }
+
+
+}
 

--- a/tests/GTestStringUtilities.h
+++ b/tests/GTestStringUtilities.h
@@ -38,38 +38,37 @@ TEST(StringUtilitiesTest, dtos)
 }
 
 
-
-
-
-
-
-TEST(StringUtilitiesTest, environment)
+TEST(StringUtilitiesTest, replaceEnvironmentVariable)
 {
     using StringUtilities::replaceEnvironmentVariable;
 
     LOG_STARTING_OF_TEST
 
-    // Test what happends when no pattern is in the inputString
+    // if no ENV['var'] pattern, the string should just be returned
 
-    string str = "Nothing here to replace";
-    EXPECT_EQ("Nothing here to replace", replaceEnvironmentVariable(str));
+    EXPECT_EQ("ABC__XYZ__DEF", replaceEnvironmentVariable("ABC__XYZ__DEF"));
 
-    // Test what happens when the environment variable is not set/known
+    // no environment variable __XYZ__ should exist at this point
 
-    str = "ENV['UNKNOWN_ENV']";
-    EXPECT_EQ("ENV['UNKNOWN_ENV']", replaceEnvironmentVariable(str));
+    EXPECT_EQ("ABCENV['__XYZ__']DEF", replaceEnvironmentVariable("ABCENV['__XYZ__']DEF"));
 
-    // Make sure the environment variable is known to the tests
+    // Make sure the environment variable __XYZ__ is known to the tests
 
-    setenv("PLATOSIM_PROJECT_HOME", "/Users/rik/Git/PlatoSim3", 1);
+    setenv("__XYZ__", "+++QWERTY+++", 1);
 
-    // Check that the pattern is properly replaced
+    string str = "ENV['__XYZ__']";
+    EXPECT_EQ("+++QWERTY+++", replaceEnvironmentVariable(str));
 
-    str = "ENV['PLATOSIM_PROJECT_HOME']";
-    EXPECT_EQ("/Users/rik/Git/PlatoSim3", replaceEnvironmentVariable(str));
+    str = "ABCENV['__XYZ__']DEF";
+    EXPECT_EQ("ABC+++QWERTY+++DEF", replaceEnvironmentVariable(str));
 
-    str = "ENV['PLATOSIM_PROJECT_HOME']/inputfiles";
-    EXPECT_EQ("/Users/rik/Git/PlatoSim3/inputfiles", replaceEnvironmentVariable(str));
+    str = "ENVENV['__XYZ__']ENV";
+    EXPECT_EQ("ENV+++QWERTY+++ENV", replaceEnvironmentVariable(str));
+
+    // Test the condition that ENV['var'] pattern is not complete (e.g. typo!)
+ 
+    str = "ENVENV['__XYZ__'}";
+    EXPECT_EQ(str, replaceEnvironmentVariable(str));
 
 }
 


### PR DESCRIPTION
GCC prior to v4.9.2 fails to implement the regex functionality of C++11. In order to support older compilers on Linux, we have replaced the use of regex with plain string functions.
