### PR TITLE
Add version information about PlatoSim3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,42 @@ project(PlatoSim)
 cmake_minimum_required(VERSION 2.8)
 
 
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  execute_process(
+    COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  execute_process(
+    COMMAND git describe
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_DESCRIBE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+else(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(GIT_BRANCH "")
+  set(GIT_DESCRIBE "")
+endif(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+
+message(STATUS "Git current branch: ${GIT_BRANCH}")
+message(STATUS "Git describe: ${GIT_DESCRIBE}")
+message(STATUS "CMake source dir: ${CMAKE_SOURCE_DIR}")
+message(STATUS "CMake current source dir: ${CMAKE_CURRENT_SOURCE_DIR}")
+message(STATUS "CMake binary dir: ${CMAKE_BINARY_DIR}")
+
+message(STATUS "Generating version.h")
+
+configure_file(
+  ${CMAKE_SOURCE_DIR}/include/version.h.in
+  ${CMAKE_BINARY_DIR}/generated/version.h
+)
 
 # Specify the locations of the header files
 
 include_directories(
+	${CMAKE_BINARY_DIR}/generated
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/Installs/hdf5-1.8.16/include
     ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/Installs/armadillo-6.500.4/include

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -14,6 +14,7 @@
 #include "JitterFromFile.h"
 #include "JitterFromRedNoise.h"
 #include "ConfigurationParameters.h"
+#include "version.h"
 
 
 using namespace std;
@@ -32,6 +33,7 @@ class Simulation
     protected:
 
         virtual void writeInputParametersToHDF5(ConfigurationParameters &configParams);
+        virtual void writeVersionInformationToHDF5();
 
     private:
 

--- a/include/version.h.in
+++ b/include/version.h.in
@@ -1,0 +1,7 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define GIT_BRANCH "@GIT_BRANCH@"
+#define GIT_DESCRIBE "@GIT_DESCRIBE@"
+
+#endif

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -41,6 +41,10 @@ Simulation::Simulation(string inputFilename, string outputFilename)
 
     hdf5File.open(outputFilename);
 
+    // Write the version info to the output HDF5 file
+
+    writeVersionInformationToHDF5();
+
     // Configure the Simulation object using the configuration parameters file
 
     configure(configParams);
@@ -150,7 +154,19 @@ void Simulation::run(double startTime)
 
 
 
+void Simulation::writeVersionInformationToHDF5()
+{
+    Log.info("Simulation: writing version information to HDF5");
 
+    // Make the parent group
+
+    string parentGroup = "/Version";
+    hdf5File.createGroup(parentGroup);
+ 
+    hdf5File.writeAttribute(parentGroup, "Application", string("PlatoSim3"));
+    hdf5File.writeAttribute(parentGroup, "GitVersion", string(GIT_DESCRIBE));
+
+}
 
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -5,6 +5,8 @@
 
 #include "Simulation.h"
 #include "Logger.h"
+#include "StringUtilities.h"
+#include "version.h"
 
 
 using namespace std;
@@ -15,12 +17,21 @@ Logger Log;
 
 int main(int Narguments, char* arguments[])
 {
+    using StringUtilities::ends_with;
+
+    if (Narguments == 2 && ends_with(arguments[1], "-version"))
+    {
+        cout << "PlatoSim " << GIT_DESCRIBE << endl;
+        exit(EXIT_SUCCESS);
+    }
+
     // Platosim expects the filename of the configuration parameters.
     // Exit if this filename is not given.
 
     if (Narguments < 3)
     {
         cerr << "Usage: platosim <inputfile> <outputfile> [<logfile>]" << endl;
+        cerr << "       platosim -version" << endl;
         exit(EXIT_FAILURE);
     }
 
@@ -37,6 +48,7 @@ int main(int Narguments, char* arguments[])
     ofstream logFile(logFilename);
     Log.addOutputStream(cerr,    WARNING | ERROR);
     Log.addOutputStream(logFile, WARNING | ERROR | DEBUG | INFO);
+    Log.info(string("PlatoSim ") + GIT_DESCRIBE);
     Log.info("Main: Log file includes 'warning', 'error', 'debug', and 'info'");
 
 


### PR DESCRIPTION
PlatoSim3 version information is now written to the log-file and into the HDF5 file.
A new optional argument -version prints the version information on the console.
