### PR TITLE
Fix a problem with ConfigurationParameters parsing integers when value is float

### DIFF
--- a/include/ConfigurationParameters.h
+++ b/include/ConfigurationParameters.h
@@ -8,6 +8,7 @@
 #include <fstream>
 
 #include "yaml-cpp/yaml.h"
+#include "yaml-cpp/exceptions.h"
 
 #include "FileUtilities.h"
 #include "StringUtilities.h"

--- a/include/Exceptions.h
+++ b/include/Exceptions.h
@@ -62,6 +62,9 @@ class IllegalArgumentException : public exception
 
 
 
+
+
+
 /**
  * \class FileException
  * \brief throw this exception for any problems with files in your code
@@ -71,6 +74,28 @@ class FileException : public exception
     public:
         FileException(const string msg);
         virtual ~FileException() throw();
+        virtual const char * what() const throw() override;
+    private:
+        string message;
+};
+
+
+
+
+
+
+
+
+
+/**
+ * \class ConfigurationException
+ * \brief throw this exception for any problems with the configuration, e.g. YAML
+ */
+class ConfigurationException : public exception 
+{
+    public:
+        ConfigurationException(const string msg);
+        virtual ~ConfigurationException() throw();
         virtual const char * what() const throw() override;
     private:
         string message;

--- a/source/ConfigurationException.cpp
+++ b/source/ConfigurationException.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+
+#include "Logger.h"
+#include "Exceptions.h"
+
+using std::string;
+
+const char * ConfigurationException::what() const throw()
+{
+    return message.c_str();
+}
+
+
+ConfigurationException::ConfigurationException(std::string msg)
+{
+    message = msg;
+    Log.error(message);
+}
+
+
+ConfigurationException::~ConfigurationException() throw() {}
+

--- a/source/ConfigurationParameters.cpp
+++ b/source/ConfigurationParameters.cpp
@@ -77,7 +77,7 @@ ConfigurationParameters::~ConfigurationParameters()
  * A boolean value is always parsed from a string that can have the following values: "yes"/"no", "y"/"n", "true"/"false", "on"/"off".
  * All the previous values can be Capitalized (i.e. start with an upper case letter) or can be all caps.
  * 
- * A boolean value can not be parsed from the integers 1 or 0.
+ * A boolean value can also be parsed from the integers 1 or 0.
  * 
  * The key is the name of the input parameter. If the input parameter is part
  * of a section or group, then the key is a combination of the group name and 
@@ -91,8 +91,39 @@ ConfigurationParameters::~ConfigurationParameters()
  */
 bool ConfigurationParameters::getBoolean(const string &key)
 {
+    bool value;
+
     YAML::Node node = getNode(key);
-    return node.as<bool>();
+
+    // First try to convert to a boolean, values should be true/false, on/off, yes/no, ..
+    // Trying to convert from an integer into a boolean will fail with an Exception.
+
+    try
+    {
+        value = node.as<bool>();
+    }
+    catch(YAML::Exception ex)
+    {
+        // Try to convert from an integer 0 or 1 
+
+        try
+        {
+            int iValue = node.as<int>();
+            if (iValue == 0)
+                value = false;
+            else if (iValue == 1)
+                value = true;
+            else
+                throw ConfigurationException("ConfigurationParameters: expected boolean value for key=\"" + key + "\", while value=" + node.as<string>());
+        }
+        catch(YAML::Exception ex)
+        {
+            throw ConfigurationException("ConfigurationParameters: cannot convert key to boolean: key=\"" + key + "\", value=" + node.as<string>());
+        }
+
+    }
+
+    return value;
 }
 
 
@@ -116,8 +147,20 @@ bool ConfigurationParameters::getBoolean(const string &key)
  */
 int ConfigurationParameters::getInteger(const string &key)
 {
+    int value;
+
     YAML::Node node = getNode(key);
-    return node.as<int>();
+
+    try
+    {
+        value = node.as<int>();
+    }
+    catch(YAML::Exception ex)
+    {
+        throw ConfigurationException("ConfigurationParameters: cannot convert key to integer: key=\"" + key + "\", value= " + node.as<string>());
+    }
+
+    return value;
 }
 
 
@@ -148,8 +191,20 @@ int ConfigurationParameters::getInteger(const string &key)
  */
 long ConfigurationParameters::getLong(const string &key)
 {
+    long value;
+
     YAML::Node node = getNode(key);
-    return node.as<long>();
+
+    try
+    {
+        value = node.as<long>();
+    }
+    catch(YAML::Exception ex)
+    {
+        throw ConfigurationException("ConfigurationParameters: cannot convert key to integer type long: key=\"" + key + "\", value= " + node.as<string>());
+    }
+
+    return value;
 }
 
 
@@ -182,8 +237,20 @@ long ConfigurationParameters::getLong(const string &key)
  */
 double ConfigurationParameters::getDouble(const string &key)
 {
+    double value;
+
     YAML::Node node = getNode(key);
-    return node.as<double>();
+
+    try
+    {
+        value = node.as<double>();
+    }
+    catch(YAML::Exception ex)
+    {
+        throw ConfigurationException("ConfigurationParameters: cannot convert key to double: key=\"" + key + "\", value= " + node.as<string>());
+    }
+
+    return value;
 }
 
 

--- a/testData/input_ConfigurationParametersTest.yaml
+++ b/testData/input_ConfigurationParametersTest.yaml
@@ -42,3 +42,7 @@ Special Values:
     boolean-false: false
     boolean-yes: yes
     boolean-no: no
+    boolean-one: 1
+    boolean-zero: 0
+    boolean-integer: 23
+    integer-float: 2.4

--- a/tests/GTestConfigurationParameters.h
+++ b/tests/GTestConfigurationParameters.h
@@ -101,10 +101,6 @@ TEST(ConfigurationParametersTest, readSpecialValues)
     int minusOneValue = cp.getInteger("Special Values/minus-one");
     EXPECT_EQ(-1, minusOneValue);
 
-    // A 0 or a 1 can not be converted into a Boolean - CHECK THIS!
-    ASSERT_ANY_THROW(cp.getBoolean("Special Values/zero"));
-    ASSERT_ANY_THROW(cp.getBoolean("Special Values/one"));
-
     bool booleanTrue = cp.getBoolean("Special Values/boolean-true");
     EXPECT_TRUE(booleanTrue);
 
@@ -116,6 +112,16 @@ TEST(ConfigurationParametersTest, readSpecialValues)
 
     bool no = cp.getBoolean("Special Values/boolean-no");
     EXPECT_FALSE(no);
+
+    bool booleanOne = cp.getBoolean("Special Values/boolean-one");
+    EXPECT_TRUE(booleanOne);
+
+    bool booleanZero = cp.getBoolean("Special Values/boolean-zero");
+    EXPECT_FALSE(booleanZero);
+
+    ASSERT_THROW(cp.getBoolean("Special Values/boolean-integer"), ConfigurationException);
+
+    ASSERT_THROW(cp.getInteger("Special Values/integer-float"), ConfigurationException);
 
 }
 


### PR DESCRIPTION
The parsing of the YAML input file crashed when parsing a integer parameter that has been given a float value in the input file. The problem  is now properly catched and a ConfigurationException is thrown.

Boolean parameters can now also understand 1 and 0 as false and true.
