### PR TITLE
Improve Python interface with PlatoSim3

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -374,12 +374,11 @@ class Simulation(object):
 
 
 
-
-
-
-    def run(self):
+    def run(self, removeOutputFile=False):
         """
-        Run the PLATO Simulator. By default, the simulation includes the photometry step. 
+        Run the PLATO Simulator.
+
+        When rerunning the same simulation again, remove the output file by setting the optional keyword to True.
         """
 
         if not self.hasTargetLocation:
@@ -388,6 +387,12 @@ class Simulation(object):
         inputFilename = "{}/{}.yaml".format(self.targetOutputFilesLocation, self.runName)
         outputFilename = "{}/{}.hdf5".format(self.targetOutputFilesLocation, self.runName)
         logFilename = "{}/{}.log".format(self.targetOutputFilesLocation, self.runName)
+
+        if removeOutputFile:
+            try:
+                os.remove(outputFilename)
+            except OSError:
+                pass
 
         self.writeYamlConfigurationFile(inputFilename)
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -379,6 +379,8 @@ class Simulation(object):
         Run the PLATO Simulator.
 
         When rerunning the same simulation again, remove the output file by setting the optional keyword to True.
+
+        When PlatoSim fails for some reason and returns an error code (!= 0), an Exception is raised.
         """
 
         if not self.hasTargetLocation:
@@ -396,7 +398,10 @@ class Simulation(object):
 
         self.writeYamlConfigurationFile(inputFilename)
 
-        subprocess.call([self.platosimBuildLocation + "/platosim", inputFilename, outputFilename, logFilename])
+        rc = subprocess.call([self.platosimBuildLocation + "/platosim", inputFilename, outputFilename, logFilename])
+
+        if rc:
+            raise Exception("Simulation.run(): PlatoSim returned with exit code {}.".format(rc))
 
         simFile = SimFile(outputFilename)
 


### PR DESCRIPTION
In Python, it often happens that the same simulation is run again in order to correct some input or enable/disable a feature. PlatoSim3 will however quit when the output file already exists (this is a protection not to accidentally overwrite an output file). This is inconvenient when running interactive (fast) simulations from within Python and we have therefore added an optional keyword 'removeOutputFile' that makes the run method remove the existing output file before starting PlatoSim.

The Simulation.run() method now catches the return code from PlatoSim and raises an Exception when PlatoSim3 failed for some reason.
