### PR TITLE
Field Distortion isn't included even though it's set within inputfgs.yaml #94

### DIFF
--- a/python/multiTelescopeConfiguration.py
+++ b/python/multiTelescopeConfiguration.py
@@ -135,11 +135,11 @@ for group in range(numTelescopeGroups):
         print "Platform pointing: " + str(raPointing) + ", " + str(decPointing)
         print "Telescope pointing: " + str(math.degrees(raTelescope)) + ", " + str(math.degrees(decTelescope))
         
-        includeFieldDistortion = (sim["Camera/IncludeFieldDistortion"] == "yes")        # Whether or not to include field distortion
-        focalPlaneAngle = sim["Camera/FocalPlaneOrientation"]                           # Focal-plane orientation [degrees]
-        focalLength = sim["Camera/FocalLength"] * 1000                                  # Focal length [mm]
-        plateScale = sim["Camera/PlateScale"]                                           # Plate scale [arcsec / micron]
-        pixelSize = sim["CCD/PixelSize"]                                                # Pixel size [micron / pixel]
+        includeFieldDistortion = (str(sim["Camera/IncludeFieldDistortion"] == "yes"))  or (str(sim["Camera/IncludeFieldDistortion"] == "1"))        # Whether or not to include field distortion
+        focalPlaneAngle = sim["Camera/FocalPlaneOrientation"]                                                                                       # Focal-plane orientation [degrees]
+        focalLength = sim["Camera/FocalLength"] * 1000                                                                                              # Focal length [mm]
+        plateScale = sim["Camera/PlateScale"]                                                                                                       # Plate scale [arcsec / micron]
+        pixelSize = sim["CCD/PixelSize"]                                                                                                            # Pixel size [micron / pixel]
         
         # Determine on which CCD (A, B, C, or D) the coordinates (raCenter, decCenter) are positioned and at which location
         # (in pixel coordinates)

--- a/python/referenceFrames.py
+++ b/python/referenceFrames.py
@@ -643,7 +643,7 @@ def drawStarInFocalPlane(sim, raStar, decStar):
 
     normal = True  # FIXME: where can we specify that we use the fast or normal Camera
 
-    if (sim["Camera/IncludeFieldDistortion"] == "yes")  or (sim["Camera/IncludeFieldDistortion"] == "1"):
+    if (str(sim["Camera/IncludeFieldDistortion"] == "yes"))  or (str(sim["Camera/IncludeFieldDistortion"] == "1")):
         includeFieldDistortion = True
         FIELD_DISTORTION["Coeff"] = sim["Camera/FieldDistortion/Coefficients"]
         FIELD_DISTORTION["InverseCoeff"] = sim["Camera/FieldDistortion/InverseCoefficients"]


### PR DESCRIPTION
Adapted referenceFrames.py and multiTelescopeConfiguration.py, to make sure field distortion is included when it is set in the configuration file (as explained in the issue).  Checked tutorials too, but they were ok.

Closes #94 