### PR TITLE
Exposure time ignored/exceeded when reading jitter from file

### DIFF
--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -481,11 +481,10 @@ void Camera::exposeDetector(Detector &detector, double startTime, double exposur
 
 
         // Update the clock. Normally with 'timeStep', but if adding timeStep would overstep
-        // the total exposure time, take the small rest time instead.
+        // the total exposure time, take the small rest time instead (but update the internal time first!).
 
-        timeStep = min(timeStep, startTime + exposureTime - internalTime);
         internalTime += timeStep;
-
+        timeStep = min(timeStep, startTime + exposureTime - internalTime);
     }
 
     // Take the flux of the stellar background and the zodiacal light into account. Use one value for the entire subfield.


### PR DESCRIPTION
_Reported by Carsten on 14/6/2017 (via email to Joris):_
The configured ExposureTime gets ignored when using a pointing time series. For example the time series is sampled with 8 Hz and I want to use 2.3 s exposure time, but PLATOSim uses 2.375 s for the exposure time instead.

Correction in Camera::exposeDetector.