### PR TITLE
Flatfield map only generated if really needed

### DIFF
--- a/source/DetectorWithAnalyticGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticGaussianPSF.cpp
@@ -36,10 +36,12 @@ DetectorWithAnalyticGaussianPSF::DetectorWithAnalyticGaussianPSF(ConfigurationPa
 
     flatfieldMap.ones(numRowsPixelMap, numColumnsPixelMap);
 
-    // Generate the flatfield map 
+    if(includeFlatfield)
+    {
+    		// Generate the flatfield map
 
-    generateFlatfieldMap();
-
+    		generateFlatfieldMap();
+    }
 }
 
 

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -142,10 +142,12 @@ DetectorWithAnalyticNonGaussianPSF::DetectorWithAnalyticNonGaussianPSF(Configura
 
     flatfieldMap.ones(numRowsPixelMap, numColumnsPixelMap);
 
-    // Generate the flatfield map 
+    if(includeFlatfield)
+    {
+    		// Generate the flatfield map
 
-    generateFlatfieldMap();
-
+    		generateFlatfieldMap();
+    }
 }
 
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -44,9 +44,12 @@ DetectorWithMappedPSF::DetectorWithMappedPSF(ConfigurationParameters &configPara
     subPixelMap.zeros(numRowsSubPixelMap, numColumnsSubPixelMap);
     flatfieldMap.ones(numRowsSubPixelMap, numColumnsSubPixelMap);
 
-    // Generate the flatfield map 
+    if(includeFlatfield)
+    {
+    		// Generate the flatfield map
 
-    generateFlatfieldMap();
+    		generateFlatfieldMap();
+    }
 
     // Initialize and load the PSF. This will open the PSF HDF5 file and perform some basic checking, 
     // Then select the proper PSF for the given subfield. Should only be done after calling configure().


### PR DESCRIPTION
In the past, the flatfield map was always generated (and stored in the output file), even if flatfielding was not being applied (i.e. IncludeFlatfield = "no").  Profiling has shown that this took a large fraction of time goes to the generation of this map.

From now on, we only generate the flatfield map in case flatfielding must be applied (i.e. IncludeFlatfield == "yes").