### PR TITLE
Flux values were always rounded down

### DIFF
--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -429,7 +429,7 @@ void Camera::exposeDetector(Detector &detector, double startTime, double exposur
             // Compute the flux [photons] of this star
             // Photons are always an integer number, so round down.
 
-            double flux = floor(fluxFactor * pow(10.0, -0.4 * star.Vmag) * timeStep);
+            double flux = round(fluxFactor * pow(10.0, -0.4 * star.Vmag) * timeStep);
 
             // Let the detector add the flux to the appropriate pixel. 
             // Detector.flux() returns the pixel coordinates to which the flux was added.


### PR DESCRIPTION
Reported by Carsten on 14/6/2017 (via email to Joris):
After switching off the quantization, I noticed that PLATOSim is always rounding down which slightly disturbs the final noise behavior.

Analysis:
In exposeDetector in Camera, the flux is calculated in photons (which should be integer numbers).  From now onwards, these values are rounded, rather than floored.