### PR TITLE
Merge branch 'angleDependency' into master

### DIFF
--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -326,10 +326,10 @@ void Detector::generateThroughputMap()
     double angle;
 
     const double refAnglePolarizationRadians = deg2rad(refAnglePolarization);       // Reference angle for the polarisation efficiency [radians]
-    const double cosPolarizationEfficiency = cos(polarizationEfficiency);
+    const double acosPolarizationEfficiency = acos(polarizationEfficiency);
 
     const double refAngleQuantumEfficiencyRadians = deg2rad(refAngleQuantumEfficiency);     // Reference angle for the quantum efficiency [radians]
-    const double cosQuantumEfficiency = cos(quantumEfficiency);
+    const double acosQuantumEfficiency = acos(quantumEfficiency);
 
     if (includeVignetting || includePolarization || includeQuantumEfficiency)
     {
@@ -354,14 +354,14 @@ void Detector::generateThroughputMap()
                 // Polarisation (Eq. 4-11 in PLATO-DLR-PL-RP-001)
 
                 if (includePolarization)
-                    throughputMap(row, column) *= cos(angle / refAnglePolarizationRadians * cosPolarizationEfficiency);
+                    throughputMap(row, column) *= cos(angle / refAnglePolarizationRadians * acosPolarizationEfficiency);
 
                 // Quantum efficiency (Eq. 4-12 in PLATO-DLR-PL-RP-001)
                 // Pixel units before: [photons]
                 // Pixel units after: [electrons]
 
                 if (includeQuantumEfficiency)
-                    throughputMap(row, column) *= cos(angle / refAngleQuantumEfficiencyRadians * cosQuantumEfficiency);
+                    throughputMap(row, column) *= cos(angle / refAngleQuantumEfficiencyRadians * acosQuantumEfficiency);
             }
         }
     }
@@ -1061,6 +1061,9 @@ void Detector::applyOpenShutterSmearing(float exposureTime)
 
     if(includeMolecularContamination)
         openShutterSmearingOutsideSubField *= molecularContaminationEfficiency;
+
+    // Sect. 4.2.4.5 of PLATO-DLR-PL-RP-001:
+    // The expected value E_ang is then the mean over all pixels and results in a value of 0.993
 
     if(includeQuantumEfficiency)
         openShutterSmearingOutsideSubField *= expectedValueQuantumEfficiency;


### PR DESCRIPTION
Correction of the angle-dependency of QE and polarisation.

Angle dependency described in PLATO-DLR-PL-RP-001:
- Sect. 4.2.4.2 (Eq. 4-11): polarisation
- Sect. 4.2.4.4 (Eq. 4-12): QE

Documenting the expected value of the QE.