### PR TITLE
GitHub issue #193: throughputMap is independent of CCD position

### DIFF
--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -335,13 +335,13 @@ void Detector::generateThroughputMap()
     {
         // Loop over all pixels in the pixel map
 
-        for (unsigned int row = subFieldZeroPointRow; row < subFieldZeroPointRow + numRowsPixelMap; row++)
+        for (unsigned int row = 0; row < numRowsPixelMap; row++)
         {
-            for (unsigned int column = subFieldZeroPointColumn; column < subFieldZeroPointColumn + numColumnsPixelMap; column++)
+            for (unsigned int column = 0; column < numColumnsPixelMap; column++)
             {
                 // Pixel coordinates (in the detector) -> focal-plane coordinates
 
-                tie(xFPmm, yFPmm) = pixelToFocalPlaneCoordinates(row, column);
+                tie(xFPmm, yFPmm) = pixelToFocalPlaneCoordinates(row + subFieldZeroPointRow, column + subFieldZeroPointColumn);
 
                 // Angular distance [radians] of the pixel from the optical axis
 


### PR DESCRIPTION
The issue was re-opened because of the occurrence of an out-of-range error.  This is fixed now in the master.