### PR TITLE
kernel dimension restrictions #211

### DIFF
--- a/source/Convolver.cpp
+++ b/source/Convolver.cpp
@@ -103,15 +103,6 @@ void Convolver::initialise(int Nrows, int Ncols, matrix &kernel)
         throw IllegalArgumentException(errorMessage);
     }
 
-    if ((kernel.n_rows > Nrows) || (kernel.n_cols > Ncols))
-    {
-        string errorMessage = "Convolver: kernel dimensions (" + to_string(kernel.n_rows) + "," 
-                            + to_string(kernel.n_cols) + ") should be smaller than input matrix dimensions "
-                            + "(" + to_string(Nrows) + "," + to_string(Ncols) + ")";
-        Log.error(errorMessage);
-        throw IllegalArgumentException(errorMessage);
-    }
-
     if ((kernel.n_rows < 2) || (kernel.n_cols < 2))
     {
         string errorMessage = "Convolver: kernel has a dimension < 2";


### PR DESCRIPTION
Removed restriction on the kernel dimensions w.r.t. the size of the image for convolution with the PSF.  Closes #211 