### PR TITLE
added functions for the charge diffusion and the subpixmap correction

### DIFF
--- a/include/Detector.h
+++ b/include/Detector.h
@@ -22,9 +22,48 @@
 #include "Logger.h"
 #include "Units.h"
 
+#include "Faddeeva.hh"
+
 using namespace std;
 
+
 class Camera;      // forward declaration
+
+
+// moved and renamed the class from DetectorWithAnalyticNonGaussianPSF.h to make it available 
+// for DetectorWithMappedPSF as well ~bert
+
+class IntegralOfAnalyticSignalResponse 
+{
+    public:
+
+        IntegralOfAnalyticSignalResponse(size_t s) : size(s), n(0.) {}
+        IntegralOfAnalyticSignalResponse& addPart(double, double, double, double, double = 0., double = 0., double = 0.);
+        double operator()(unsigned, unsigned, bool = true);
+
+    private:
+
+        size_t size;                              // number of (sub)pixels in one dimension
+        double n;                                 // normalization factor
+        vector<valarray<double>> erfxr;           // evaluated error functions for x
+        vector<valarray<double>> erfyr;           // evaluated error functions for y
+        vector<valarray<complex<double>>> erfxc;  // evaluated complex error functions for x
+        vector<valarray<complex<double>>> erfyc;  // evaluated complex error functions for y
+};
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -216,6 +255,20 @@ class Detector: public HDF5Writer
  
         Camera &camera;
         FrontEndElectronics *frontEndElectronics;
+
+        // define the parameters used for charge diffusion and subpixel map correction
+
+        bool includeChargeDiffusion;
+        bool includeSubPixelMapCorrection;
+
+        double chargeDiffusionParameter;
+        double correctionParameter;
+
+        unsigned int numRowsSubPixelMap;
+        unsigned int numColumnsSubPixelMap;
+        unsigned int numSubPixelsPerPixel;
+
+        arma::Mat<float> subPixelMap;
 
     private:
 

--- a/include/DetectorWithAnalyticNonGaussianPSF.h
+++ b/include/DetectorWithAnalyticNonGaussianPSF.h
@@ -10,7 +10,7 @@
 #include <valarray>
 
 #include "armadillo"
-#include "Faddeeva.hh"
+
 
 #include "Constants.h"
 #include "Units.h"
@@ -19,32 +19,6 @@
 
 
 using namespace std;
-
-
-
-class IntegralOfAnalyticPSF 
-{
-    public:
-
-        IntegralOfAnalyticPSF(size_t s) : size(s), n(0.) {}
-        IntegralOfAnalyticPSF& addPart(double, double, double, double, double = 0., double = 0., double = 0.);
-        double operator()(unsigned, unsigned, bool = true);
-
-    private:
-
-        size_t size;                              // number of (sub)pixels in one dimension
-        double n;                                 // normalization factor
-        vector<valarray<double>> erfxr;           // evaluated error functions for x
-        vector<valarray<double>> erfyr;           // evaluated error functions for y
-        vector<valarray<complex<double>>> erfxc;  // evaluated complex error functions for x
-        vector<valarray<complex<double>>> erfyc;  // evaluated complex error functions for y
-};
-
-
-
-
-
-
 
 
 
@@ -64,7 +38,7 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
         virtual tuple<bool, double, double> addFlux(double xFP, double yFP, double flux) override;
         virtual void addFlux(double flux) override;
 
-        void integrateAnalyticPSF(IntegralOfAnalyticPSF&, double, double, double, double, double = 1.);
+        void integrateAnalyticPSF(IntegralOfAnalyticSignalResponse&, double, double, double, double, double = 1.);
 
 
     protected:

--- a/include/DetectorWithMappedPSF.h
+++ b/include/DetectorWithMappedPSF.h
@@ -44,7 +44,7 @@ class DetectorWithMappedPSF: public Detector
 
         PointSpreadFunction *psf;
 
-        arma::Mat<float> subPixelMap;           // Sub-pixel map, incl. edge pixels
+        //arma::Mat<float> subPixelMap;           // Sub-pixel map, incl. edge pixels
         arma::Mat<float> psfMap;                // The PSF map that will be used for convolving
         arma::Mat<float> flatfieldMap;          // Intra-pixel flatfield map
 
@@ -55,13 +55,13 @@ class DetectorWithMappedPSF: public Detector
         bool includeConvolution;                // Whether or not to convolve the subPixelMap with the PSF
 
 
-        unsigned int numRowsSubPixelMap;        // Nr of subpixel rows in the subfield incl. edge pixels (= size in the y-direction) [subpixels]
-        unsigned int numColumnsSubPixelMap;     // Nr of subpixel columns in the subfield incl. edge pixels (= size in the x-direction = readout direction) [subpixels]
-        unsigned int numSubPixelsPerPixel;      // Nr of sub-pixels per pixel
+        //unsigned int numRowsSubPixelMap;        // Nr of subpixel rows in the subfield incl. edge pixels (= size in the y-direction) [subpixels]
+        //unsigned int numColumnsSubPixelMap;     // Nr of subpixel columns in the subfield incl. edge pixels (= size in the x-direction = readout direction) [subpixels]
+        //unsigned int numSubPixelsPerPixel;      // Nr of sub-pixels per pixel
         
         long flatfieldSeed;
 
-
+        void subPixelMapCorrection(double subpixColumn, double subpixRow, double correctionParameter, double flux);
 
     private:
 

--- a/inputfiles/inputfgs.yaml
+++ b/inputfiles/inputfgs.yaml
@@ -205,6 +205,12 @@ CCD:
     IncludeDigitalSaturation:        yes             # Whether or not digital saturation should be applied
     IncludeQuantisation:             yes             # Whether or not to include quantisation
 
+    IncludeChargeDiffusion:          yes             # whether or not the effects of charge diffusion should be used
+    IncludeSubPixelMapCorrection:    no              # inluding the effects of SubPixelMapCorrection, this is only relevant, when Charge Diffuion is deactivated
+
+    ChargeDiffusionParameter:        0.2             # strength of the charge diffsuion
+
+
 
 SubField:    
 

--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -204,6 +204,11 @@ CCD:
     IncludeDigitalSaturation:        yes             # Whether or not digital saturation should be applied
     IncludeQuantisation:             yes             # Whether or not to include quantisation
 
+    IncludeChargeDiffusion:          yes             # whether or not the effects of charge diffusion should be used
+    IncludeSubPixelMapCorrection:    no              # inluding the effects of SubPixelMapCorrection, this is only relevant, when Charge Diffuion is deactivated
+
+    ChargeDiffusionParameter:        0.2             # strength of the charge diffsuion
+
 
 SubField:    
 

--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -1,5 +1,120 @@
 #include "Detector.h"
 
+
+
+
+
+
+
+/**
+ * \brief Add a part to the definite integral of the analytic PSF and adjust the normalization factor accordingly.
+ * 
+ * \param ox:    relative x offset
+ * \param oy:    relative y offset
+ * \param h:     relative height
+ * \param sigma: width of Gaussian term
+ * \param r:     strength and type of periodic term
+ * \param rho:   distance between Gaussian term and periodic term
+ * \param phi:   orientation of periodic term
+ * 
+ * \return reference to itself
+ **/
+
+IntegralOfAnalyticSignalResponse& IntegralOfAnalyticSignalResponse::addPart(double ox, double oy, double h, double sigma, double r, double rho, double phi) 
+{
+    using Faddeeva::erf;
+    
+    ox += (size - (size & 1)) / 2.;
+    oy += (size - (size & 1)) / 2.;
+
+    erfxr.emplace_back(size + 1);
+    erfyr.emplace_back(size + 1);
+    double sr = 1. / sqrt(2.) / sigma;
+    double fr1 = sqrt(M_PI * fabs(h) * sigma * sigma / (r != 0.? 4.: 2.)); 
+    double fr2 = h < 0.? -fr1: fr1; 
+
+    erfxr.back()[0] = erf(-sr * ox);
+    erfyr.back()[0] = erf(-sr * oy);
+    for (unsigned i = 0; i < size; i++) 
+    {
+        erfxr.back()[i] = ((erfxr.back()[i + 1] = erf(sr * (i + 1. - ox))) - erfxr.back()[i]) * fr1;
+        erfyr.back()[i] = ((erfyr.back()[i + 1] = erf(sr * (i + 1. - oy))) - erfyr.back()[i]) * fr2;
+    }
+    n += 4. * fr1 * fr2;
+
+    if (r != 0.) 
+    {
+        erfxc.emplace_back(size + 1);
+        erfyc.emplace_back(size + 1);
+        double delta = 2. * M_PI * sigma * sigma / r / r;
+        complex<double> sc = sr * sqrt(complex<double>(1., delta));
+        complex<double> xc = complex<double>(0., M_PI / fabs(r) * sqrt(rho) * cos(phi)) / sc;
+        complex<double> yc = complex<double>(0., M_PI / fabs(r) * sqrt(rho) * sin(phi)) / sc;
+        complex<double> fc = sqrt((r < 0.? -fr1: fr1) * fr2 * exp(-M_PI * rho / (1. + delta * delta) * complex<double>(delta, 1.)) / complex<double>(1., delta));
+
+        erfxc.back()[0] = erf(xc - sc * ox);
+        erfyc.back()[0] = erf(yc - sc * oy);
+        for (unsigned i = 0; i < size; i++) 
+        {
+            erfxc.back()[i] = ((erfxc.back()[i + 1] = erf(xc + sc * (i + 1. - ox))) - erfxc.back()[i]) * fc;
+            erfyc.back()[i] = ((erfyc.back()[i + 1] = erf(yc + sc * (i + 1. - oy))) - erfyc.back()[i]) * fc;
+        }
+        n -= 4. * (fc.real() * fc.real() - fc.imag() * fc.imag());
+    }
+    return *this;
+}
+
+
+
+/**
+ * \brief Get integral of analytic PSF for a (sub)pixel.
+ * 
+ * \param i:    x direction 
+ * \param j:    y direction 
+ * \param norm: apply normalization 
+ * 
+ * \return normalized or unnormalized integral of analytic PSF for (sub)pixel (i, j)
+ **/
+
+double IntegralOfAnalyticSignalResponse::operator()(unsigned i, unsigned j, bool norm) 
+{
+    if (i >= size || j >= size)
+    {
+        return 0.;
+    }
+    
+    double ret = 0.;
+    for (unsigned k = 0; k < erfxr.size() && k < erfyr.size(); k++)
+    {    
+        ret += erfxr[k][i] * erfyr[k][j];
+    }
+    
+    for (unsigned k = 0; k < erfxc.size() && k < erfyc.size(); k++)
+    {
+        ret -= erfxc[k][i].real() * erfyc[k][j].real() - erfxc[k][i].imag() * erfyc[k][j].imag();
+    }
+
+    return norm? ret / n: ret;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /**
  * \brief Constructor.
  * 
@@ -92,6 +207,20 @@ Detector::Detector(ConfigurationParameters &configParam, HDF5File &hdf5file, Cam
     fastForwardReadoutNoiseGeneratorToExposure(beginExposureNr);
     fastForwardPhotonNoiseGeneratorToExposure(beginExposureNr);
     fastForwardCosmicsGeneratorToExposure(beginExposureNr, exposureTime);
+
+    // initialize parameters for charge diffusion and subpixel map correction
+
+    if (includeChargeDiffusion)
+    {
+        correctionParameter = numSubPixelsPerPixel * chargeDiffusionParameter;
+    }
+    else
+    {
+        correctionParameter = 0.5;
+    }
+
+    subPixelMap.zeros(numRowsSubPixelMap, numColumnsSubPixelMap);
+
 }
 
 
@@ -282,6 +411,20 @@ void Detector::updateParameters(double time)
     beginExposureNr         = configParam.getInteger("ObservingParameters/BeginExposureNr");
 
     numEdgePixels = 0;
+
+    //include the parameters used for charge diffusion and suppixelcorrection
+
+    includeChargeDiffusion          = configParam.getBoolean("CCD/IncludeChargeDiffusion");
+    includeSubPixelMapCorrection    = configParam.getBoolean("CCD/IncludeSubPixelMapCorrection");
+
+    chargeDiffusionParameter        = configParam.getDouble("CCD/ChargeDiffusionParameter");
+
+    numSubPixelsPerPixel            = configParam.getInteger("SubField/SubPixels");
+
+    // derive the dimensions of the sub-pixel map
+
+    numRowsSubPixelMap      =   numRowsPixelMap     * numSubPixelsPerPixel;
+    numColumnsSubPixelMap   =   numColumnsPixelMap  * numSubPixelsPerPixel;
  }
 
 
@@ -2490,4 +2633,8 @@ double Detector::getTemperature()
 {
 	return temperatureGenerator.getNextTemperature(internalTime);
 }
+
+
+
+
 

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -2,108 +2,6 @@
 
 
 
-/**
- * \brief Add a part to the definite integral of the analytic PSF and adjust the normalization factor accordingly.
- * 
- * \param ox:    relative x offset
- * \param oy:    relative y offset
- * \param h:     relative height
- * \param sigma: width of Gaussian term
- * \param r:     strength and type of periodic term
- * \param rho:   distance between Gaussian term and periodic term
- * \param phi:   orientation of periodic term
- * 
- * \return reference to itself
- **/
-
-IntegralOfAnalyticPSF& IntegralOfAnalyticPSF::addPart(double ox, double oy, double h, double sigma, double r, double rho, double phi) 
-{
-    using Faddeeva::erf;
-    
-    ox += (size - (size & 1)) / 2.;
-    oy += (size - (size & 1)) / 2.;
-
-    erfxr.emplace_back(size + 1);
-    erfyr.emplace_back(size + 1);
-    double sr = 1. / sqrt(2.) / sigma;
-    double fr1 = sqrt(M_PI * fabs(h) * sigma * sigma / (r != 0.? 4.: 2.)); 
-    double fr2 = h < 0.? -fr1: fr1; 
-
-    erfxr.back()[0] = erf(-sr * ox);
-    erfyr.back()[0] = erf(-sr * oy);
-    for (unsigned i = 0; i < size; i++) 
-    {
-        erfxr.back()[i] = ((erfxr.back()[i + 1] = erf(sr * (i + 1. - ox))) - erfxr.back()[i]) * fr1;
-        erfyr.back()[i] = ((erfyr.back()[i + 1] = erf(sr * (i + 1. - oy))) - erfyr.back()[i]) * fr2;
-    }
-    n += 4. * fr1 * fr2;
-
-    if (r != 0.) 
-    {
-        erfxc.emplace_back(size + 1);
-        erfyc.emplace_back(size + 1);
-        double delta = 2. * M_PI * sigma * sigma / r / r;
-        complex<double> sc = sr * sqrt(complex<double>(1., delta));
-        complex<double> xc = complex<double>(0., M_PI / fabs(r) * sqrt(rho) * cos(phi)) / sc;
-        complex<double> yc = complex<double>(0., M_PI / fabs(r) * sqrt(rho) * sin(phi)) / sc;
-        complex<double> fc = sqrt((r < 0.? -fr1: fr1) * fr2 * exp(-M_PI * rho / (1. + delta * delta) * complex<double>(delta, 1.)) / complex<double>(1., delta));
-
-        erfxc.back()[0] = erf(xc - sc * ox);
-        erfyc.back()[0] = erf(yc - sc * oy);
-        for (unsigned i = 0; i < size; i++) 
-        {
-            erfxc.back()[i] = ((erfxc.back()[i + 1] = erf(xc + sc * (i + 1. - ox))) - erfxc.back()[i]) * fc;
-            erfyc.back()[i] = ((erfyc.back()[i + 1] = erf(yc + sc * (i + 1. - oy))) - erfyc.back()[i]) * fc;
-        }
-        n -= 4. * (fc.real() * fc.real() - fc.imag() * fc.imag());
-    }
-    return *this;
-}
-
-
-
-
-
-
-
-
-
-/**
- * \brief Get integral of analytic PSF for a (sub)pixel.
- * 
- * \param i:    x direction 
- * \param j:    y direction 
- * \param norm: apply normalization 
- * 
- * \return normalized or unnormalized integral of analytic PSF for (sub)pixel (i, j)
- **/
-
-double IntegralOfAnalyticPSF::operator()(unsigned i, unsigned j, bool norm) 
-{
-    if (i >= size || j >= size)
-    {
-        return 0.;
-    }
-    
-    double ret = 0.;
-    for (unsigned k = 0; k < erfxr.size() && k < erfyr.size(); k++)
-    {    
-        ret += erfxr[k][i] * erfyr[k][j];
-    }
-    
-    for (unsigned k = 0; k < erfxc.size() && k < erfyc.size(); k++)
-    {
-        ret -= erfxc[k][i].real() * erfyc[k][j].real() - erfxc[k][i].imag() * erfyc[k][j].imag();
-    }
-
-    return norm? ret / n: ret;
-}
-
-
-
-
-
-
 
 
 /**
@@ -283,7 +181,7 @@ void DetectorWithAnalyticNonGaussianPSF::updateParameters(double time)
  * \param scale: scale factor to resize the PSF
  **/
 
-void DetectorWithAnalyticNonGaussianPSF::integrateAnalyticPSF(IntegralOfAnalyticPSF& psf, double x, double y, double r, double p, double scale) 
+void DetectorWithAnalyticNonGaussianPSF::integrateAnalyticPSF(IntegralOfAnalyticSignalResponse& psf, double x, double y, double r, double p, double scale) 
 {
     double ox = x - floor(x);
     double oy = y - floor(y);
@@ -603,7 +501,7 @@ tuple<bool, double, double> DetectorWithAnalyticNonGaussianPSF::addFlux(double x
     if (sx + size <= 0 || sx >= (int)numColumnsPixelMap || sy + size <= 0 || sy >= (int)numRowsPixelMap)
         return make_tuple(false, row0, column0);
 
-    IntegralOfAnalyticPSF psf(size);
+    IntegralOfAnalyticSignalResponse psf(size);
     double r = rad2deg(camera.getGnomonicRadialDistanceFromOpticalAxis(xFP, yFP));
     double p = atan2(yFP, xFP);
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -41,7 +41,7 @@ DetectorWithMappedPSF::DetectorWithMappedPSF(ConfigurationParameters &configPara
 
     // Allocate memory for the different maps
 
-    subPixelMap.zeros(numRowsSubPixelMap, numColumnsSubPixelMap);
+    //subPixelMap.zeros(numRowsSubPixelMap, numColumnsSubPixelMap);
     flatfieldMap.ones(numRowsSubPixelMap, numColumnsSubPixelMap);
 
     if(includeFlatfield)
@@ -108,7 +108,7 @@ DetectorWithMappedPSF::~DetectorWithMappedPSF()
 
     writeSubPixelImagesToHDF5 = configParam.getBoolean("ControlHDF5Content/WriteSubPixelImages");
 
-    numSubPixelsPerPixel    = configParam.getInteger("SubField/SubPixels");
+    //numSubPixelsPerPixel    = configParam.getInteger("SubField/SubPixels");
 
     // Configuration parameters for the noise source random seeds
 
@@ -116,8 +116,8 @@ DetectorWithMappedPSF::~DetectorWithMappedPSF()
 
     // Derive the dimensions of the sub-pixel map
 
-    numRowsSubPixelMap    = numRowsPixelMap    * numSubPixelsPerPixel;  // TODO Add edge pixels
-    numColumnsSubPixelMap = numColumnsPixelMap * numSubPixelsPerPixel;  // TODO Add edge pixels
+    //numRowsSubPixelMap    = numRowsPixelMap    * numSubPixelsPerPixel;  // TODO Add edge pixels
+    //numColumnsSubPixelMap = numColumnsPixelMap * numSubPixelsPerPixel;  // TODO Add edge pixels
 
  }
 
@@ -437,21 +437,31 @@ tuple<bool, double, double> DetectorWithMappedPSF::addFlux(double xFP, double yF
     // (subpixRow, subpixColumn) are the indices of the star in the subpixelMap. So they are not 
     // subpixel coordinates in the CCD frame, but in the subfield reference frame.
 
-    const double subpixColumn = round((pixColumn - subFieldZeroPointColumn + numEdgePixels) * numSubPixelsPerPixel);
-    const double subpixRow    = round((pixRow    - subFieldZeroPointRow    + numEdgePixels) * numSubPixelsPerPixel);
+    const double subpixColumn = (pixColumn - subFieldZeroPointColumn + numEdgePixels) * numSubPixelsPerPixel;
+    const double subpixRow    = (pixRow    - subFieldZeroPointRow    + numEdgePixels) * numSubPixelsPerPixel;
 
     // Convert back the _rounded_ subpixel coordinates to pixel coordinates
     // E.g. if there are 4 subpixels per pixel, then the pixel coordinates should always end with
     //      0.0, 0.25, 0.5, or 0.75
 
-    pixRow    = subpixRow    / numSubPixelsPerPixel - numEdgePixels;
-    pixColumn = subpixColumn / numSubPixelsPerPixel - numEdgePixels;
+    pixRow    = round(subpixRow)    / numSubPixelsPerPixel - numEdgePixels;
+    pixColumn = round(subpixColumn) / numSubPixelsPerPixel - numEdgePixels;
 
     // Add the flux to the subPixelMap
 
-    if (isInSubPixelMap(subpixRow, subpixColumn))
+    if (isInSubPixelMap(round(subpixRow), round(subpixColumn)))
     {
-        subPixelMap((int) subpixRow, (int) subpixColumn) += flux;
+        //if charrge diffusion or subpixelmapcorrection is used, the flux is added as a gaussian signal response on the subpixelmap
+        if (includeChargeDiffusion || includeSubPixelMapCorrection)
+        {
+            //the calculation of the signal response is the same for charge diffusion and subpixelmap correction, only the parameter changes
+            subPixelMapCorrection(subpixColumn, subpixRow, correctionParameter, flux);
+        }
+        else
+        {
+            subPixelMap((int) subpixRow, (int) subpixColumn) += flux;
+        }
+
         return make_tuple(true, pixRow, pixColumn);
     }
     else
@@ -461,6 +471,31 @@ tuple<bool, double, double> DetectorWithMappedPSF::addFlux(double xFP, double yF
 }
 
 
+// function to either include charge diffusion, or subpixelmap correction within the subpixelmap
+// it uses functions originally written for the analytic psf creation
+
+void DetectorWithMappedPSF::subPixelMapCorrection(double subpixColumn, double subpixRow, double correctionParameter, double flux)
+{
+    int size = 2 * (int)(8. * correctionParameter +1) + 1;
+
+    int sx = (int)floor(subpixColumn - (size - 1.) / 2.);
+    int sy = (int)floor(subpixRow - (size - 1.) / 2.);
+
+    IntegralOfAnalyticSignalResponse signalResponse(size);
+
+    double ox = subpixColumn - floor(subpixColumn);
+    double oy = subpixRow - floor(subpixRow);
+
+    signalResponse.addPart(ox, oy, 1., correctionParameter);
+
+    for(int y = max(0, sy); y < min((int)numRowsSubPixelMap, sy + size); y++)
+    {
+        for(int x = max(0, sx); x < min((int)numColumnsSubPixelMap, sx + size); x++)
+        {
+            subPixelMap.at(y, x) += signalResponse(x - sx, y - sy) * flux;
+        }
+    }
+}
 
 
 
@@ -729,7 +764,6 @@ void DetectorWithMappedPSF::writeSubPixelMapToHDF5(int exposureNr)
 
     hdf5File.writeArray("/SubPixelImages", imageName, subPixelMap);
 }
-
 
 
 

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -539,6 +539,15 @@ void Simulation::writeInputParametersToHDF5(ConfigurationParameters &configParam
     addBoolean("IncludeFullWellSaturation");
     addBoolean("IncludeQuantisation");
     addBoolean("IncludeDigitalSaturation");
+
+    //include parameters for charge diffusion and subpixelmap correction
+
+    addBoolean("IncludeChargeDiffusion");
+    addBoolean("IncludeSubPixelMapCorrection");
+
+    addDouble("ChargeDiffusionParameter");
+
+
     // addBoolean("WriteSubPixelImagesToHDF5"); - Moved into ControlHDF5Content group below
 
 	subGroup = "CCD/Gain";


### PR DESCRIPTION
This should include the charge diffusion effect for mapped psf's in the simulation. For that, some functions from the IntegralOfAnalyticPSF class within DetectorWithAnalyticNonGaussianPSF were used. The class was renamed and moved to the Detector class.
The function used for adding the actual charge diffusion (void DetectorWithMappedPSF::subPixelMapCorrection(...)) can be used for the subPixelMapCorrection as well. All that changes is the "correctionParameter", which is dependent on the new parameters within the input file (IncludeChargeDiffusion, IncludeSubPixelMapCorrection and ChargeDiffusionParameter).
Keep in mind, that the charge diffusion effect "overwrites" the subpixelmap correction so only one can be used at a time (however there is no technical limitation).   