### PR TITLE
If UseJitter == no, then the jitter file is no longer read, even when UseJitterFromFile == yes.

### DIFF
--- a/include/NoDrift.h
+++ b/include/NoDrift.h
@@ -1,0 +1,43 @@
+#ifndef NODRIFT_H
+#define NODRIFT_H 
+
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <random>
+#include <functional>
+
+#include "Logger.h"
+#include "Units.h"
+#include "Exceptions.h"
+#include "Heartbeat.h"
+#include "HDF5Writer.h"
+#include "ConfigurationParameters.h"
+#include "DriftGenerator.h"
+
+
+using namespace std;
+
+
+
+class NoDrift: public DriftGenerator
+{
+    public:
+
+        NoDrift();
+        ~NoDrift();
+
+        virtual void configure();
+        virtual tuple<double, double, double> getNextYawPitchRoll(double time) override;
+        virtual double getHeartbeatInterval() override;
+
+    protected:
+
+    private:
+
+ };
+
+
+
+#endif
+ 

--- a/include/NoJitter.h
+++ b/include/NoJitter.h
@@ -1,0 +1,45 @@
+#ifndef NOJITTER_H
+#define NOJITTER_H
+
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <random>
+#include <functional>
+#include <limits>
+
+#include "Logger.h"
+#include "Units.h"
+#include "Heartbeat.h"
+#include "HDF5Writer.h"
+#include "ConfigurationParameters.h"
+#include "JitterGenerator.h"
+
+
+using namespace std;
+
+
+
+// Null Object Pattern for a null generator, always returning (yaw, pitch, roll)=(0,0,0)
+
+class NoJitter: public JitterGenerator
+{
+    public:
+
+        NoJitter();
+        ~NoJitter();
+
+        virtual void configure(ConfigurationParameters &configParams);
+        virtual tuple<double, double, double> getNextYawPitchRoll(double time) override;
+        virtual double getHeartbeatInterval() override;
+
+    protected:
+
+    private:
+
+ };
+
+
+
+#endif
+ 

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -17,9 +17,11 @@
 #include "Platform.h"
 #include "Sky.h"
 #include "JitterGenerator.h"
+#include "NoJitter.h"
 #include "JitterFromFile.h"
 #include "JitterFromRedNoise.h"
 #include "DriftGenerator.h"
+#include "NoDrift.h"
 #include "ThermoElasticDriftFromFile.h"
 #include "ThermoElasticDriftFromRedNoise.h"
 #include "ConfigurationParameters.h"
@@ -54,8 +56,10 @@ class Simulation
         int beginExposureNr;                 // sequential number of first exposure. useful for slurm parallellisation
         int numExposures;                    // Number of exposures
 
+        bool useJitter;
         bool useJitterFromFile;
         bool includeFieldDistortion;
+        bool useDrift;
         bool useDriftFromFile;
         bool useFeeTemperatureFromFile;
         bool useFeeNominalTemperature;

--- a/source/NoDrift.cpp
+++ b/source/NoDrift.cpp
@@ -1,0 +1,89 @@
+#include "NoDrift.h"
+
+
+
+/**
+ * \brief Constructor
+ * 
+ * \param configParams The configuration parameters from the input parameters file
+ */
+
+NoDrift::NoDrift()
+{
+}
+
+
+
+
+
+
+
+
+
+
+/**
+ * \brief Destructor
+ */
+
+NoDrift::~NoDrift()
+{
+
+}
+
+
+
+
+
+
+
+/**
+ * \brief Configure this object using the parameters from the input parameters file
+ * 
+ * \param configParams  The configuration parameters
+ */
+
+void NoDrift::configure()
+{
+}
+
+
+
+
+
+
+
+
+
+/**
+ * \brief With No Drift, simply always return (yaw, pitch, roll)=(0,0,0)
+ * \return (0, 0, 0)  [rad]
+ */
+
+tuple<double, double, double> NoDrift::getNextYawPitchRoll(double time)
+{
+    return make_tuple(0.0, 0.0, 0.0);
+}
+
+
+
+
+
+
+
+
+/**
+ * \brief Return the heartbeat interval. For this null generator this is in principle
+ *        infinity, in practice the largest double value.
+ * 
+ * \details The heartbeat interval is the drift time interval which is set to a fraction of 
+ *          the drift time scale. so that the changes in (yaw, pitch, roll) can still be 
+ *          reliably tracked.
+ *          
+ * \return  heartbeatInterval [s]
+ */
+
+double NoDrift::getHeartbeatInterval()
+{
+    return numeric_limits<double>::max();
+}
+

--- a/source/NoJitter.cpp
+++ b/source/NoJitter.cpp
@@ -1,0 +1,89 @@
+#include "NoJitter.h"
+
+
+
+/**
+ * \brief Constructor
+ * 
+ */
+
+NoJitter::NoJitter()
+{
+}
+
+
+
+
+
+
+
+
+
+
+/**
+ * \brief Destructor
+ */
+
+NoJitter::~NoJitter()
+{
+
+}
+
+
+
+
+
+
+
+/**
+ * \brief Configure this object using the parameters from the input parameters file
+ * 
+ * \param configParams  The configuration parameters
+ */
+
+void NoJitter::configure(ConfigurationParameters &configParams)
+{
+}
+
+
+
+
+
+
+
+
+
+/**
+ * \brief With No jitter, simply always return (yaw, pitch, roll)=(0,0,0)
+ * \return (0, 0, 0)  [rad]
+ */
+
+tuple<double, double, double> NoJitter::getNextYawPitchRoll(double time)
+{
+
+    return make_tuple(0.0, 0.0, 0.0);
+}
+
+
+
+
+
+
+
+
+/**
+ * \brief Return the heartbeat interval. For this null generator this is in principle
+ *        infinity, in practice the largest double value.
+ *
+ * \details The heartbeat interval is the jitter time interval which is set to a fraction of 
+ *          the jitter time scale. so that the changes in (yaw, pitch, roll) can still be 
+ *          reliably tracked.
+ *          
+ * \return  heartbeatInterval [s]
+ */
+
+double NoJitter::getHeartbeatInterval()
+{
+    return numeric_limits<double>::max();
+}
+

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -51,24 +51,38 @@ Simulation::Simulation(string inputFilename, string outputFilename)
 
     // Depending on what the user requested, define the proper platform jitter generator
 
-    if (useJitterFromFile)
+    if (!useJitter)
     {
-        jitterGenerator = new JitterFromFile(configParams);
+        jitterGenerator = new NoJitter();
     }
     else
     {
-        jitterGenerator = new JitterFromRedNoise(configParams);
+        if (useJitterFromFile)
+        {
+            jitterGenerator = new JitterFromFile(configParams);
+        }
+        else
+        {
+            jitterGenerator = new JitterFromRedNoise(configParams);
+        }
     }
 
     // Depending on what the user requested, define the proper telescope thermo-elastic drift generator
 
-    if (useDriftFromFile)
+    if (!useDrift)
     {
-        driftGenerator = new ThermoElasticDriftFromFile(configParams);
+        driftGenerator = new NoDrift();
     }
     else
     {
-        driftGenerator = new ThermoElasticDriftFromRedNoise(configParams);
+        if (useDriftFromFile)
+        {
+            driftGenerator = new ThermoElasticDriftFromFile(configParams);
+        }
+        else
+        {
+            driftGenerator = new ThermoElasticDriftFromRedNoise(configParams);
+        }
     }
 
     if(useFeeTemperatureFromFile)
@@ -167,8 +181,10 @@ void Simulation::configure(ConfigurationParameters &configParams)
     exposureTime      = configParams.getDouble("ObservingParameters/ExposureTime"); 
     beginExposureNr   = configParams.getInteger("ObservingParameters/BeginExposureNr");
     numExposures      = configParams.getInteger("ObservingParameters/NumExposures");
+    useJitter         = configParams.getBoolean("Platform/UseJitter");
     useJitterFromFile = configParams.getBoolean("Platform/UseJitterFromFile");
     includeFieldDistortion = configParams.getBoolean("Camera/IncludeFieldDistortion"); // do we want to do this or should this be asked to Camera?
+    useDrift          = configParams.getBoolean("Telescope/UseDrift");  
     useDriftFromFile  = configParams.getBoolean("Telescope/UseDriftFromFile");  
     psfModel          = configParams.getString("PSF/Model");
     useFeeTemperatureFromFile = configParams.getString("FEE/Temperature") == "FromFile";


### PR DESCRIPTION
Idem for the drift. This saves time.
Implementation details: the Null Object Pattern was used: two new classes: NoJitter and NoDrift were created. Adapted Simulation accordingly.