### PR TITLE
Feature/feature 247

### DIFF
--- a/include/DetectorWithMappedPSF.h
+++ b/include/DetectorWithMappedPSF.h
@@ -34,7 +34,7 @@ class DetectorWithMappedPSF: public Detector
         virtual void initHDF5Groups() override;
         virtual void integrateLight(int exposureNr, double startTime, double exposureTime) override;
         virtual bool isInSubPixelMap(double row, double column);
-        virtual void applyDiffusionKernel(int row, int column, double flux);
+        virtual void applyDiffusionKernel(double row, double column, double flux);
         virtual void applyFlatfield() override;
         virtual void generateFlatfieldMap();
         virtual void generateDiffusionKernel(double kernelWidth);

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -525,7 +525,7 @@ tuple<bool, double, double> DetectorWithMappedPSF::addFlux(double xFP, double yF
  * \param subpixColumn: Column index [sub-pixels].  NOT a coordinate in the CCD frame, but in the subfield frame.
  * \param flux: Flux for which to apply charge diffusion or jitter smoothing [photons].
  */
-void DetectorWithMappedPSF::applyDiffusionKernel(int subpixRow, int subpixColumn, double flux)
+void DetectorWithMappedPSF::applyDiffusionKernel(double subpixRow, double subpixColumn, double flux)
 {
 	int sx = subpixColumn - (diffusionKernelImageSize - 1) / 2;
 	int sy = subpixRow - (diffusionKernelImageSize - 1) / 2;
@@ -545,10 +545,6 @@ void DetectorWithMappedPSF::applyDiffusionKernel(int subpixRow, int subpixColumn
 			diffusionKernel(row, column) = signalResponse(column, row);
 		}
 	}
-
-	// Normalisation
-
-	diffusionKernel /= arma::accu(diffusionKernel);
 
 	// Add the flux to the sub-pixel map
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -542,7 +542,7 @@ void DetectorWithMappedPSF::applyDiffusionKernel(double subpixRow, double subpix
 	{
 		for (unsigned int column = 0; column < diffusionKernelImageSize; column++)
 		{
-			diffusionKernel(row, column) = signalResponse(column, row);
+			diffusionKernel(row, column) = signalResponse(column, row);	// Normalisation done by ()-operator
 		}
 	}
 


### PR DESCRIPTION
Addressing issues raised in #247 

- The function `DetectorWithMappedPSF::applyDiffusionKernel()` declares the input values `subpixRow` and `subpixCoulumn` as`int` - they should be `double`, or `ox` and `oy` will always be zero.
- Omitting normalisation of the diffusion kernel, as this already taken care of by the `()`-operator in the `IntegralOfAnalyticSignalResponse` class.