### PR TITLE
Path to executable set to /build in simulation.py

### DIFF
--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -104,8 +104,8 @@ PSF:
         RotationAngle:              -1               # PSF rotation angle w.r.t the x-axis of the focal plane. -1 to auto-compute. [deg]
         NumberOfPixels:              8               # The number of pixels in the field for which the PSF is generated
         ChargeDiffusionStrength:     0.2             # Charge diffusion strength (width of the Gaussian diffusion kernel) [pixels]
-        IncludeChargeDiffusion:      no             # Include charge diffusion [yes or no]
-        IncludeJitterSmoothing:      no             # Include jitter smoothing [yes or no]
+        IncludeChargeDiffusion:      no              # Include charge diffusion [yes or no]
+        IncludeJitterSmoothing:      no              # Include jitter smoothing [yes or no]
     AnalyticGaussian:                                # Generate the PSF analytically from a non-spherical Gaussian
         Sigma00:                     1.0             # Stdev of Gaussian PSF in x- and y-direction at the optical axis      [pix]
         SigmaX18:                    5.0             # Stdev of Gaussian PSF in x-direction at 18 deg from the optical axis [pix]

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -131,18 +131,22 @@ class Simulation(object):
         # Find the absolute path of the simfile.py. This will allow us to located the other
         # default project directories. Build in a test to check that the build sub-directory 
         # exists, otherwise this is probably not a correct default installation.
-
-        path = inspect.getabsfile(simfile)
-        path = os.path.dirname(path)  # strip off filename of the simfile module: simfile.py
-        path = os.path.dirname(path)  # strip off python sub-directory
-        if not os.path.isdir(path + "/build"):
-            raise Exception("Unexpected directory structure for this PLATO Simulator distribution: no build sub-directory")
+        
+        path = os.environ["PLATO_PROJECT_HOME"]
         
         self.platosimLocation = path
-
-        # This is the location of the platosim executable
-
-        self.platosimBuildLocation = self.platosimLocation + "/build"
+        
+        if os.path.exists(path + "/build"):
+            self.platosimBuildLocation = self.platosimLocation + "/build"
+            
+        elif os.path.exists(path + "/bin"):
+            self.platosimBuildLocation = self.platosimLocation + "/bin"
+            
+        else:
+            raise Exception("Unexpected directory structure for this PLATO Simulator distribution: no build nor bin sub-directory in PLATO_PROJECT_HOME")
+        
+            
+        
 
         # This is the location of the original input files as distributed by the PLATO Simulator
         


### PR DESCRIPTION
Where the executable resides depends on how the PlatoSim software was installed:

* installed via GitHub: in `$PLATO_PROJECT_HOME/build`
* installed via conda: in `$PLATO_PROJECT_HOME/bin`

Fixing now in the `develop` branch.