### PR TITLE
User-given sky background not multiplied with the transmissivity of the optics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Dark edge seen at bottom of the sub-field due to CTI by Short et al. (GitHub issue # 263)
 
+* User-given sky background not multiplied with the transmissivity of the optics (GitHub issue #265)
+
 
 <!-- 3.3.2 -->
 <!-- ***** -->

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -659,7 +659,7 @@ void Camera::exposeDetector(Detector &detector, double startTime, double exposur
     }
     else
     {
-        totalSkyBackground = floor(userGivenSkyBackground * exposureTime);
+        totalSkyBackground = floor(userGivenSkyBackground * exposureTime * transmissionEfficiency);
         detector.addFlux(totalSkyBackground);
 
         Log.debug("Camera: user-given sky background flux = " + to_string(userGivenSkyBackground * exposureTime) + " photons/pixel/exposure");


### PR DESCRIPTION
Closes #265.