### PR TITLE
Photon flux of stars should be floored instead of rounded (in the jitter steps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * User-given sky background not multiplied with the transmissivity of the optics (GitHub issue #265)
 
+* Photon flux of stars should be floored instead of rounded (in the jitter steps) (GitHub issue #267)
+
 
 <!-- 3.3.2 -->
 <!-- ***** -->

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -567,7 +567,7 @@ void Camera::exposeDetector(Detector &detector, double startTime, double exposur
             // Compute the flux [photons] of this star
             // Photons are always an integer number, so round down.
 
-            double flux = round(fluxFactor * pow(10.0, -0.4 * Vmag) * timeStep);
+            double flux = floor(fluxFactor * pow(10.0, -0.4 * Vmag) * timeStep);
 
             // Let the detector add the flux to the appropriate pixel. 
             // Detector.flux() returns the pixel coordinates to which the flux was added.


### PR DESCRIPTION
Closes #267 