### PR TITLE
Open-shutter smearing outside sub-field should not take numRowsBiasMap into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Photon flux of stars should be floored instead of rounded (in the jitter steps) (GitHub issue #267)
 
+* Open-shutter smearing outside sub-field should not take numRowsBiasMap into account (GitHub issue #269)
+
 
 <!-- 3.3.2 -->
 <!-- ***** -->

--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -1661,7 +1661,7 @@ void Detector::applyOpenShutterSmearing(float exposureTime)
 
     arma::Row<float> openShutterSmearing = arma::sum(pixelMap, 0);
 
-    float openShutterSmearingOutsideSubField = camera.getTotalSkyBackground() * (numRows - numRowsPixelMap + numRowsBiasMap + numRowsSmearingMap);
+    float openShutterSmearingOutsideSubField = camera.getTotalSkyBackground() * (numRows - numRowsPixelMap + numRowsSmearingMap);
 
     // Apply all throughput efficiencies
 


### PR DESCRIPTION
Closes #269 