### PR TITLE
GitHub issue #294: inconsistency in star position output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 * Bias register map expressed as additional columns (GitHub issue #290)
 
+* Inconsistency in star position output (GitHub issue #294)
+
 
 <!-- 3.3.4 -->
 <!-- ***** -->

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -500,11 +500,11 @@ tuple<bool, double, double> DetectorWithMappedPSF::addFlux(double xFP, double yF
     			subPixelMap((int) floor(subpixRow), (int) floor(subpixColumn)) += flux;
     		}
 
-        return make_tuple(true, pixRow, pixColumn);
+        return make_tuple(true, pixRow - subFieldZeroPointRow, pixColumn - subFieldZeroPointColumn);
     }
     else
     {
-        return make_tuple(false, pixRow, pixColumn);
+        return make_tuple(false, pixRow - subFieldZeroPointRow, pixColumn - subFieldZeroPointColumn);
     }
 }
 


### PR DESCRIPTION
Pinpointed the problem to the `addFlux` method in `DetectorWithMappedPSF`, where the sub-field zeropoint is not subtracted from the pixel coordinates, in contrast to the `addFlux` method in `DetectorWithAnalyticGaussianPSF` and `DetectorWithAnalyticNonGaussianPSF`.

Added the subtraction in `DetectorWithMappedPSF`.