### PR TITLE
GitHub issue #302: Improved error trapping for CCD readout mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,19 @@
 
 * Backward compatibility to the configuration files? (GitHub issue #292)
 
+* Improve documentation on supplementary input files of PlatoSim (GitHub issue #308)
+
+* Migtool error (GitHub issue #307)
+
 * Update HDF5 dependency to 1.10.2 (GitHub issue #322)
+
+* Remove python 3.5 dependency (GitHub issue #318)
+
+* Improved error trapping for CCD/ReadoutMode/ReadoutMode (GitHub issue #302)
+
+
+
+
 
 
 

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -247,6 +247,12 @@ pair<double, double> Simulation::configureReadoutTime(ConfigurationParameters &c
 
 	string readoutMode = configParams.getString("CCD/ReadoutMode/ReadoutMode");
 
+	if((readoutMode != "Nominal") && (readoutMode != "Partial"))
+	{
+		Log.error("Simulation::configureReadoutTime(): Unknown readout mode specification in configuration file: "  + readoutMode);
+		throw ConfigurationException("Simulation: Unknown readout mode specification in configuration file");
+	}
+
 	double serialTransferTime = configParams.getDouble("CCD/SerialTransferTime") * 1E-9;			  // [ns] -> [s]
 	double parallelTransferTime = configParams.getDouble("CCD/ParallelTransferTime") * 1E-6;		  // [µs] -> [s]
 	double parallelTransferTimeFast = configParams.getDouble("CCD/ParallelTransferTimeFast") * 1E-6;  // [µs] -> [s]
@@ -309,7 +315,6 @@ pair<double, double> Simulation::configureReadoutTime(ConfigurationParameters &c
 			numRowsReadout = numRowsPartialReadout;
 			numRowsDump = firstRowExposed - numRowsReadout;
 		}
-
 
 		readoutTimeDuringNextExposure = numRowsDump * parallelTransferTimeFast
 				+ numRowsReadout * (parallelTransferTime + numColumnsReadout * serialTransferTime);


### PR DESCRIPTION
Exception already thrown in the `Simulation` class, rather than to wait for the `Detector` class.