### PR TITLE
GitHub issue #325: incorrect sky background level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 * Improved error trapping for CCD/ReadoutMode/ReadoutMode (GitHub issue #302)
 
+* Incorrect sky background level (GitHub issue #325)
+
 
 
 ### Added

--- a/docs/tutorials/ParameterReview/ConfigurationParameters.ipynb
+++ b/docs/tutorials/ParameterReview/ConfigurationParameters.ipynb
@@ -1282,7 +1282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -1291,7 +1291,7 @@
      "text": [
       "CCD gain: 1.8 µV / e- (temperature stability: 0.004 µV / e- / K)\n",
       "\n",
-      "FEE gain (normal cameras): 0.022222222222222223 ADU / µV (temperature stability: 0.0003 ADU / µV / K)\n",
+      "FEE gain (normal cameras): 0.02777777777777778 ADU / µV (temperature stability: 0.0003 ADU / µV / K)\n",
       "FEE gain (fast cameras): 0.009107468123861567 ADU / µV (temperature stability: 0.0003 ADU / µV / K)\n"
      ]
     }
@@ -1299,7 +1299,7 @@
    "source": [
     "# Total gain [e- / ADU]\n",
     "\n",
-    "totalGainNormal = 25    # Total gain for the normal cameras\n",
+    "totalGainNormal = 20    # Total gain for the normal cameras\n",
     "totalGainFast = 61      # Total gain for the fast cameras\n",
     "\n",
     "# CCD gain\n",

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -42,7 +42,7 @@ class Camera : public HDF5Writer
         virtual ~Camera();
 
         virtual void configure(ConfigurationParameters &configParam);
-        virtual void exposeDetector(Detector &detector, double startTime, double exposureTime);
+        virtual void exposeDetector(Detector &detector, double startTime, double exposureTime, double readoutTimeBeforeNextExposure);
         virtual void updateParameters(double time);
 
         virtual void initHDF5Groups() override;

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -422,9 +422,10 @@ void Camera::updateParameters(double time)
  * \param[in]  detector      the Detector class
  * \param[in]  startTime     start time of the exposure [seconds]
  * \param[in]  exposureTime  duration of one exposure [seconds]
+ * \param readoutTimeBeforeNextExposure Duration of the readout that takes place before the next exposure can start [seconds]
  */
 
-void Camera::exposeDetector(Detector &detector, double startTime, double exposureTime)
+void Camera::exposeDetector(Detector &detector, double startTime, double exposureTime, double readoutTimeBeforeNextExposure)
 {
     // Get the value for the degrading TransmissionEfficiency parameter at the startTime of this exposure
 
@@ -499,7 +500,7 @@ void Camera::exposeDetector(Detector &detector, double startTime, double exposur
 
         // The time at the middle of the time series is the time when the Sun is defined to be 180 degrees away from platform pointing
 
-        double timeMiddle = numExposures * (exposureTime + detector.getReadoutTimeBeforeNextExposure()) / 2.0;
+        double timeMiddle = numExposures * (exposureTime + readoutTimeBeforeNextExposure) / 2.0;
 
         // Get the apparent position of the stars, i.e. apply the differential aberration correction to
         // all the star positions in this starCatalog.
@@ -643,11 +644,11 @@ void Camera::exposeDetector(Detector &detector, double startTime, double exposur
         const double lambda2 = (throughputLambdaC + throughputBandwidth/2.0) * 1.e-9;                                         // [m]
     
         const double zodiacalFlux = sky.zodiacalFlux(centerRA, centerDec, lambda1, lambda2)                                   // [phot/exposure]
-                                    * exposureTime * transmissionEfficiency * telescope.getLightCollectingArea()
+                                    * (exposureTime + readoutTimeBeforeNextExposure) * transmissionEfficiency * telescope.getLightCollectingArea()
                                     * detector.getSolidAngleOfOnePixel(plateScale) / energyOfOnePhoton; 
 
         const double stellarBackgroundFlux = sky.stellarBackgroundFlux(centerRA, centerDec, lambda1, lambda2)                 // [phot/exposure]
-                                             * exposureTime * transmissionEfficiency * telescope.getLightCollectingArea()
+                                             * (exposureTime + readoutTimeBeforeNextExposure) * transmissionEfficiency * telescope.getLightCollectingArea()
                                              * detector.getSolidAngleOfOnePixel(plateScale) / energyOfOnePhoton;      
 
 
@@ -659,10 +660,11 @@ void Camera::exposeDetector(Detector &detector, double startTime, double exposur
     }
     else
     {
-        totalSkyBackground = floor(userGivenSkyBackground * exposureTime * transmissionEfficiency);
+        totalSkyBackground = floor(userGivenSkyBackground * (exposureTime + readoutTimeBeforeNextExposure) * transmissionEfficiency);
         detector.addFlux(totalSkyBackground);
 
-        Log.debug("Camera: user-given sky background flux = " + to_string(userGivenSkyBackground * exposureTime) + " photons/pixel/exposure");
+        Log.debug("Camera: user-given sky background flux over exposure= " + to_string(userGivenSkyBackground * exposureTime) + " photons/pixel/exposure");
+        Log.debug("Camera: user-given sky background flux over readout= " + to_string(userGivenSkyBackground * readoutTimeBeforeNextExposure) + " photons/pixel/readout");
     }
 
     // Save the sky background value that we added. [photons/pix/exposure]

--- a/source/DetectorWithAnalyticGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticGaussianPSF.cpp
@@ -292,7 +292,7 @@ void DetectorWithAnalyticGaussianPSF::integrateLight(int exposureNr, double star
     // Integration (incl. jitter): point sources + background
     // PixelMap units after: [photons]
 
-    camera.exposeDetector(*this, startTime, exposureTime);
+    camera.exposeDetector(*this, startTime, exposureTime, readoutTimeBeforeNextExposure);
 
     // Apply flatfield (at pixel level)
     // PixelMap units after: [photons]

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -419,7 +419,7 @@ void DetectorWithAnalyticNonGaussianPSF::integrateLight(int exposureNr, double s
 
     // Integration (incl. jitter): point sources + background
 
-    camera.exposeDetector(*this, startTime, exposureTime);
+    camera.exposeDetector(*this, startTime, exposureTime, readoutTimeBeforeNextExposure);
 
     // Apply flatfield (at pixel level)
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -392,7 +392,7 @@ void DetectorWithMappedPSF::integrateLight(int exposureNr, double startTime, dou
 
     // Integration (incl. jitter): point sources + background
 
-    camera.exposeDetector(*this, startTime, exposureTime);
+    camera.exposeDetector(*this, startTime, exposureTime, readoutTimeBeforeNextExposure);
 
     // Convolve with the point spread function
 


### PR DESCRIPTION
* Normal cam: background accumulated during readout
* Fast cam: background accumulated over the duration of the frame transfer (no further accumulation during the readout of the lower CCD half, as this is shielded off)