### PR TITLE
Writing pixel / bias / smearing maps in unsigned int to the HDF5 file. 

### DIFF
--- a/include/HDF5File.h
+++ b/include/HDF5File.h
@@ -47,6 +47,7 @@ class HDF5File
         void writeArray(string groupName, string arrayName, float*        array, int size);
         void writeArray(string groupName, string arrayName, double*       array, int size);
         void writeArray(string groupName, string arrayName, arma::Mat<float>& A);
+        void writeArray(string groupName, string arrayName, arma::Mat<unsigned int>& A);
 
         double readDoubleGroupAttribute(string groupName, string attributeName);
         int readIntegerGroupAttribute(string groupName, string attributeName);

--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -2576,8 +2576,23 @@ void Detector::writePixelMapsToHDF5(int exposureNr)
 
     // Add the image to the "Images" group
 
-    hdf5File.writeArray("/Images", imageName, pixelMap);
+    if (!includeQuantisation)
+    {
+        // Write the float array to HDF5
+        
+        hdf5File.writeArray("/Images", imageName, pixelMap);
+    }
+    else
+    {
+        // Convert the float matrix to an unsigned int matrix.
+        // Since a float is 32 bytes, and an unsigned int 16 bytes, it saves half the space.
+        
+        arma::Mat<unsigned int> uintMap = arma::conv_to<arma::Mat<unsigned int>>::from(pixelMap);
+        hdf5File.writeArray("/Images", imageName, uintMap);
+    }
 
+    // Write the Smearing map to the HDF5 file
+    
     if(numRowsSmearingMap != 0)
     {
     	// Clear the string stream and compose the smearing map name
@@ -2588,10 +2603,21 @@ void Detector::writePixelMapsToHDF5(int exposureNr)
     	myStream << "smearingMap" << setfill('0') << setw(6) << exposureNr;
     	string smearingMapName = myStream.str();
 
-
     	// Add the smearing map to the "SmearingMaps" group
 
-    	hdf5File.writeArray("/SmearingMaps", smearingMapName, smearingMap);
+        if (!includeQuantisation)
+        {
+            // Write the float array to HDF5
+            
+            hdf5File.writeArray("/SmearingMaps", smearingMapName, smearingMap);
+        }
+        else
+        {
+            // Convert the float matrix to an unsigned int matrix.
+            
+            arma::Mat<unsigned int> uintMap = arma::conv_to<arma::Mat<unsigned int>>::from(smearingMap);
+            hdf5File.writeArray("/SmearingMaps", smearingMapName, uintMap);
+        }
     }
 
    // Clear the string stream and compose the bias map name
@@ -2604,10 +2630,27 @@ void Detector::writePixelMapsToHDF5(int exposureNr)
 
     // Add the bias map to the "BiasMaps" group
 
-    hdf5File.writeArray("/BiasMapsLeft", biasMapName, biasMapLeft);
-    hdf5File.writeArray("/BiasMapsRight", biasMapName, biasMapRight);
+    if (!includeQuantisation)
+    {
+        // Write the float array to HDF5
+        
+        hdf5File.writeArray("/BiasMapsLeft", biasMapName, biasMapLeft);
+        hdf5File.writeArray("/BiasMapsRight", biasMapName, biasMapRight);
+    }
+    else
+    {
+        // Convert the float matrix to an unsigned int matrix.
+        
+        arma::Mat<unsigned int> uintMap = arma::conv_to<arma::Mat<unsigned int>>::from(biasMapLeft);
+        hdf5File.writeArray("/BiasMapsLeft", biasMapName, uintMap);
+        
+        uintMap = arma::conv_to<arma::Mat<unsigned int>>::from(biasMapRight);
+        hdf5File.writeArray("/BiasMapsRight", biasMapName, uintMap);
+    }
+
 
     // Clear the string stream and compose the throughput map name
+
 
     myStream.str(string());      // insert empty string
     myStream.clear();            // clear eof bit

--- a/source/HDF5File.cpp
+++ b/source/HDF5File.cpp
@@ -1518,6 +1518,98 @@ void HDF5File::writeArray(string groupName, string arrayName, arma::Mat<float>& 
 
 
 
+
+// HDF5File::writeArray()  for 2D unsigned int armadillo arrays
+//
+// PURPOSE: write a 2D armadillo array to a specified group in the HDF5 file.
+//
+// INPUT: array: 2D armadillo array
+//        groupName: name of an existing HDF5 Group in the file. Starts with "/".
+//        arrayName: unique name of the array in the group, e.g. "image000001"
+//
+// OUTPUT: None
+
+void HDF5File::writeArray(string groupName, string arrayName, arma::Mat<unsigned int>& A)
+{
+    // Sanity check on the shape of the array
+
+    if ((A.n_rows == 0) && (A.n_cols == 0))
+    {
+        throw H5FileException("HDF5File::writeArray(): encountered array with shape (0,0)");
+    }
+
+    // Create a DataSpace defining the shape and type of the data 
+
+    unsigned int Ndimensions = 2;
+    unsigned long long shape[Ndimensions];
+    shape[0] = A.n_rows;
+    shape[1] = A.n_cols;
+    H5::DataSpace arraySpace(Ndimensions, shape);
+
+    // Check if the array is not already in the file.
+    // There seems to be only a dirty way of determining this:
+    // try to access the dataset, and check if an exception is thrown.
+
+    bool arrayIsAlreadyInFile = true;
+    string arrayPath = groupName + "/" + arrayName;
+
+    try 
+    {  
+        // Turn off the auto-printing when an exception is raised
+
+        H5::Exception::dontPrint();
+
+        // Try to open the dataset
+
+        H5::DataSet testDataset = file->openDataSet(arrayPath.c_str());
+    }
+    catch (H5::FileIException error)
+    {
+        arrayIsAlreadyInFile = false;
+    }
+
+    if (arrayIsAlreadyInFile)
+    {
+        throw H5GroupException("HDF5File::writeArray(): array " + groupName + "/" + arrayName + " already in file.");
+    }
+
+    // Inside the Images group, make room for the image array
+
+    H5::DataSet arrayDataset = file->createDataSet(arrayPath.c_str(), H5::PredType::NATIVE_UINT, arraySpace);
+    
+    // Copy the Armadillo array to a vector, because the internally Armadillo stores the data column-major
+    // while HDF5 assumes data to be stored row-major
+
+    vector<unsigned int> temp(A.n_rows * A.n_cols);
+    for (int n = 0; n < A.n_rows; n++)
+    {
+        for(int k = 0; k < A.n_cols; k++)
+        {
+            const int nk = n * A.n_cols + k;
+            temp[nk] = A(n,k);
+        }
+    }
+
+    // Copy the data from our image into the HDF5 file
+
+    arrayDataset.write(temp.data(), H5::PredType::NATIVE_UINT);
+
+    // That's it
+
+    return;
+}
+
+
+
+
+
+
+
+
+
+
+
+
 // HDF5File::readArray() for 2D float armadillo arrays
 //
 // PURPOSE: read a 2D array from a specified group in the HDF5 file into an


### PR DESCRIPTION
Cf Issue #348. 
Depending on whether 'includeQuantisation' is set to yes/no in the yaml inputfile, Detector now writes pixelMaps, biasMaps, and smearingMaps as unsigned int/float arrays in the HDF5 file. This reduces the map size with 50 % (32 -> 16 bits per pixel).

The current version is fairly transparant, but not particular efficient: the 'float' armadillo array is converted to an 'unsigned int' armadillo array. HDF5File then converts the latter to 'unsigned int' C++ vector, which is then written to HDF5. This implies two copies. An alternative could be to add an argument to HDF5File::writeArray(string groupName, string arrayName, arma::Mat<float>& A, convertToUInts=False) and change this function accordingly so that only one copy is needed: one from a 'float' arma array to an 'unsigned int' vector. This approach seems a bit hacky, though...