### PR TITLE
Write uint arrays

### DIFF
--- a/include/HDF5File.h
+++ b/include/HDF5File.h
@@ -47,6 +47,7 @@ class HDF5File
         void writeArray(string groupName, string arrayName, float*        array, int size);
         void writeArray(string groupName, string arrayName, double*       array, int size);
         void writeArray(string groupName, string arrayName, arma::Mat<float>& A);
+        void writeArray(string groupName, string arrayName, arma::Mat<unsigned int>& A);
 
         double readDoubleGroupAttribute(string groupName, string attributeName);
         int readIntegerGroupAttribute(string groupName, string attributeName);

--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -2574,9 +2574,25 @@ void Detector::writePixelMapsToHDF5(int exposureNr)
     myStream << "image" << setfill('0') << setw(6) << exposureNr;
     string imageName = myStream.str();
 
-    // Add the image to the "Images" group
 
-    hdf5File.writeArray("/Images", imageName, pixelMap);
+    // if quantisation is applied the pixelmap is written to a int mat - this should save space
+
+    if ((arma::accu(arma::floor(pixelMap) - pixelMap) == 0) && (pixelMap.max() <= 65535) && (pixelMap.min() >= 0))
+    {
+        arma::Mat<unsigned int> intPixelMap;
+        intPixelMap = arma::conv_to<arma::Mat<unsigned int>>::from(pixelMap);
+
+        // Add the image to the "Images" group
+
+        hdf5File.writeArray("/Images", imageName, intPixelMap);
+    }
+    else
+    {
+        // Add the image to the "Images" group
+
+        hdf5File.writeArray("/Images", imageName, pixelMap);
+    }
+
 
     if(numRowsSmearingMap != 0)
     {

--- a/source/HDF5File.cpp
+++ b/source/HDF5File.cpp
@@ -1512,6 +1512,86 @@ void HDF5File::writeArray(string groupName, string arrayName, arma::Mat<float>& 
 
 
 
+// HDF5File::writeArray()  for 2D int armadillo arrays
+//
+// PURPOSE: write a 2D armadillo array to a specified group in the HDF5 file.
+//
+// INPUT: array: 2D armadillo array
+//        groupName: name of an existing HDF5 Group in the file. Starts with "/".
+//        arrayName: unique name of the array in the group, e.g. "image000001"
+//
+// OUTPUT: None
+
+void HDF5File::writeArray(string groupName, string arrayName, arma::Mat<unsigned int>& A)
+{
+    // Sanity check on the shape of the array
+
+    if ((A.n_rows == 0) && (A.n_cols == 0))
+    {
+        throw H5FileException("HDF5File::writeArray(): encountered array with shape (0,0)");
+    }
+
+    // Create a DataSpace defining the shape and type of the data 
+
+    unsigned int Ndimensions = 2;
+    unsigned long long shape[Ndimensions];
+    shape[0] = A.n_rows;
+    shape[1] = A.n_cols;
+    H5::DataSpace arraySpace(Ndimensions, shape);
+
+    // Check if the array is not already in the file.
+    // There seems to be only a dirty way of determining this:
+    // try to access the dataset, and check if an exception is thrown.
+
+    bool arrayIsAlreadyInFile = true;
+    string arrayPath = groupName + "/" + arrayName;
+
+    try 
+    {  
+        // Turn off the auto-printing when an exception is raised
+
+        H5::Exception::dontPrint();
+
+        // Try to open the dataset
+
+        H5::DataSet testDataset = file->openDataSet(arrayPath.c_str());
+    }
+    catch (H5::FileIException error)
+    {
+        arrayIsAlreadyInFile = false;
+    }
+
+    if (arrayIsAlreadyInFile)
+    {
+        throw H5GroupException("HDF5File::writeArray(): array " + groupName + "/" + arrayName + " already in file.");
+    }
+
+    // Inside the Images group, make room for the image array
+
+    H5::DataSet arrayDataset = file->createDataSet(arrayPath.c_str(), H5::PredType::NATIVE_UINT16, arraySpace);
+    
+    // Copy the Armadillo array to a vector, because the internally Armadillo stores the data column-major
+    // while HDF5 assumes data to be stored row-major
+
+    vector<uint16_t> temp(A.n_rows * A.n_cols);
+    for (int n = 0; n < A.n_rows; n++)
+    {
+        for(int k = 0; k < A.n_cols; k++)
+        {
+            const int nk = n * A.n_cols + k;
+            temp[nk] = uint16_t(A(n,k));
+        }
+    }
+
+    // Copy the data from our image into the HDF5 file
+
+    arrayDataset.write(temp.data(), H5::PredType::NATIVE_UINT16);
+
+    // That's it
+
+    return;
+}
+
 
 
 


### PR DESCRIPTION
my proposal to deal with the question in Issue #348.

It's basically the same as Joris solution, but it checks beforehand, whether an imagette is suited to be saved as an unsigned int array, to avoid information loss. I don't know, whether this is really necessary and can lead to other problems, when there is a mix of float and uint arrays in the output file. 
Furthermore AFAIK the NATIVE_UINT data type the hdf5 package is using, still uses 32 bit. I suggest to use the NATIVE_UINT16 data type.