### PR TITLE
Bug fix in the createStarCatalogFileFromPixelCoordinates() method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 
 * Conserving disc space by writing the images as int matrices into the .hdf5 files (GitHub issue #348)
 
+* Bug fix in the createStarCatalogFileFromPixelCoordinates() method.
+
 
 
 ### Added

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -745,6 +745,7 @@ class Simulation(object):
         focalLength     = self["Camera/FocalLength/ConstantValue"] * 1000.0                     # [m] -> [mm]
         includeFieldDistortion = self["Camera/IncludeFieldDistortion"]
         inverseDistortionCoefficients = self["Camera/FieldDistortion/ConstantInverseCoefficients"]
+        solarPanelOrientation = np.deg2rad(float(self["Platform/SolarPanelOrientation"]))
 
         # Convert the pixel coordinates to focal plane coordinates [mm]
       
@@ -757,7 +758,7 @@ class Simulation(object):
 
         # Convert the focal plane coordinates to equatorial sky coordinates [rad]
 
-        ra, dec = rf.focalPlaneToSkyCoordinates(xFPmm, yFPmm, raPlatform, decPlatform, tiltAngle, azimuthAngle, focalPlaneAngle, focalLength)
+        ra, dec = rf.focalPlaneToSkyCoordinates(xFPmm, yFPmm, raPlatform, decPlatform, solarPanelOrientation, tiltAngle, azimuthAngle, focalPlaneAngle, focalLength)
 
         # Convert sky coordinates to degrees
         


### PR DESCRIPTION
The solar-panel orientation was missing from the call of the focalPlaneToSkyCoordinates() method.