### PR TITLE
Avoiding negative entries in star locations

### DIFF
--- a/include/Detector.h
+++ b/include/Detector.h
@@ -85,6 +85,7 @@ class Detector: public HDF5Writer
         virtual void addFlux(double flux) = 0;
 
 
+        bool isInPixelMap(double row, double column);
         bool isInSubfield(double xFPmm, double yFPmm);
 
         double getReadoutTimeBeforeNextExposure();

--- a/include/DetectorWithAnalyticGaussianPSF.h
+++ b/include/DetectorWithAnalyticGaussianPSF.h
@@ -37,7 +37,6 @@ class DetectorWithAnalyticGaussianPSF: public Detector
         virtual void integrateLight(int exposureNr, double startTime, double exposureTime) override;
         virtual void applyFlatfield() override;
         virtual void generateFlatfieldMap();
-        virtual bool isInPixelMap(double row, double column);
 
         arma::Mat<float> flatfieldMap;      // Pixel flatfield map
 

--- a/include/DetectorWithAnalyticNonGaussianPSF.h
+++ b/include/DetectorWithAnalyticNonGaussianPSF.h
@@ -44,7 +44,6 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
         virtual void integrateLight(int exposureNr, double startTime, double exposureTime) override;
         virtual void applyFlatfield() override;
         virtual void generateFlatfieldMap();
-        virtual bool isInPixelMap(double row, double column);
 
         Parameter<double> *sigma;           // Width of the analytic PSF, equal to sigma for a Gaussian PSF
         vector<vector<double>> params;      // Table of analytic PSF parameters

--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -785,6 +785,40 @@ bool Detector::isInSubfield(double xFP, double yFP)
 
 
 
+
+
+
+
+
+
+ /**
+ * \brief   Check whether the given (row, column) indices are within the array range of the pixel map.
+ *
+ * \details  The input parameters row & column come from a coordinate transformation
+ *           in the focal plane, and as a result are not necessarily integers. For this 
+ *           function it's not necessary to round them to the nearest integer. 
+ *
+ * \param  row:    Row index. NOT a coordinate in the CCD frame, but in the subfield frame.    [pixel].
+ * \param  column: Column index. NOT a coordinate in the CCD frame, but in the subfield frame. [pixel].
+ *
+ * \return  True if the given (row, column) coordinates are in the pixel map; false otherwise.
+ */
+
+bool Detector::isInPixelMap(double row, double column)
+{
+    return (column >= 0) && (row >= 0) && (column < numColumnsPixelMap) && (row < numRowsPixelMap);
+}
+
+
+
+
+
+
+
+
+
+
+
 /**
  * \brief Apply throughput efficiency. This is the combined effect of:
  *          - vignetting (brightness attenuation towards the edges of the FOV);

--- a/source/DetectorWithAnalyticGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticGaussianPSF.cpp
@@ -468,35 +468,6 @@ tuple<bool, double, double> DetectorWithAnalyticGaussianPSF::addFlux(double xFP,
 
 
 
-
-/**
- * \brief   Check whether the given (row, column) indices are within the array range of the pixel map.
- *
- * \details  The input parameters row & column come from a coordinate transformation
- *           in the focal plane, and as a result are not necessarily integers. For this 
- *           function it's not necessary to round them to the nearest integer. 
- *
- * \param  row:    Row index. NOT a coordinate in the CCD frame, but in the subfield frame.    [pixel].
- * \param  column: Column index. NOT a coordinate in the CCD frame, but in the subfield frame. [pixel].
- *
- * \return  True if the given (row, column) coordinates are in the pixel map; false otherwise.
- */
-
-bool DetectorWithAnalyticGaussianPSF::isInPixelMap(double row, double column)
-{
-    return (column >= 0) && (row >= 0) && (column < numColumnsPixelMap) && (row < numRowsPixelMap);
-}
-
-
-
-
-
-
-
-
-
-
-
 /**
  * \brief: Add the given flux value to (all sub-pixels of) the sub-pixel map.
  *

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -511,6 +511,13 @@ tuple<bool, double, double> DetectorWithAnalyticNonGaussianPSF::addFlux(double x
     row0 -= subFieldZeroPointRow;
     column0 -= subFieldZeroPointColumn;
 
+    // Check if the star falls in the subfield. If not, don't add any flux, but simply return.
+
+    if (!isInPixelMap(row0, column0))
+    {
+        return make_tuple(false, row0, column0);
+    }
+
     double s = (*sigma)();
     double d = 0.;
 
@@ -541,35 +548,6 @@ tuple<bool, double, double> DetectorWithAnalyticNonGaussianPSF::addFlux(double x
             pixelMap.at(y, x) += psf(x - sx, y - sy) * flux;
 
     return make_tuple(true, row0, column0);
-}
-
-
-
-
-
-
-
-
-
-
-
-
-/**
- * \brief   Check whether the given (row, column) indices are within the array range of the pixel map.
- *
- * \details  The input parameters row & column come from a coordinate transformation
- *           in the focal plane, and as a result are not necessarily integers. For this 
- *           function it's not necessary to round them to the nearest integer. 
- *
- * \param  row:    Row index. NOT a coordinate in the CCD frame, but in the subfield frame.    [pixel].
- * \param  column: Column index. NOT a coordinate in the CCD frame, but in the subfield frame. [pixel].
- *
- * \return  True if the given (row, column) coordinates are in the pixel map; false otherwise.
- */
-
-bool DetectorWithAnalyticNonGaussianPSF::isInPixelMap(double row, double column)
-{
-    return (column >= 0) && (row >= 0) && (column < numColumnsPixelMap) && (row < numRowsPixelMap);
 }
 
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -482,6 +482,13 @@ tuple<bool, double, double> DetectorWithMappedPSF::addFlux(double xFP, double yF
     pixRow -= subFieldZeroPointRow;
     pixColumn -= subFieldZeroPointColumn;
 
+    // Check if the star falls in the subfield. If not, don't add any flux, but simply return.
+
+    if (!isInPixelMap(pixRow, pixColumn))
+    {
+        return make_tuple(false, pixRow, pixColumn);
+    }
+
     // Sub-field coordinates, taking into account the edge pixels 
     // (subpixRow, subpixColumn) are the indices of the star in the subpixelMap. So they are not 
     // sub-pixel coordinates in the CCD frame, but in the subfield reference frame.


### PR DESCRIPTION
* Added check in the `addFlux` method of all classes extending `Detector`
* Moved `isInPixelMap` to `Detector`