### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ generated/version.h
 # Un-ignore some of the default input files in the inputfiles/ folder
 
 !inputfiles/inputfile.yaml
+!inputfiles/inputfgs.yaml
+!inputfiles/photometryTargets.txt
 !starField_RA180Dec-70.txt
 !psfallv3.txt
 

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -63,6 +63,8 @@ class Simulation
         int beginExposureNr;                    // sequential number of first exposure. useful for slurm parallellisation
         int numExposures;                       // Number of exposures
 
+        double timeShift;                       // Time shift between the different CCDs [s] 
+
         bool useJitter;
         string jitterSource;
         bool includeFieldDistortion;

--- a/inputfiles/inputfgs.yaml
+++ b/inputfiles/inputfgs.yaml
@@ -157,7 +157,7 @@ CCD:
     NumColumns:                  4510            # Number of columns [pixels]
     NumRows:                     4510            # Number of rows [pixels]
     FirstRowExposed:             0               # The index of the first row that is exposed to light [pixels]
-
+    TimeShift:                   0.0             # Extra time shift of the first exposure. Autoset when Position is in [1,2,3,4]. [s]
     PixelSize:                   18              # [micron]
     BFE:                                             # Brighter-fatter effect
         Range:                       2               # How far pixels can be apart and still influence each other [pixels] (use window with dimensions 2 * range + 1)
@@ -308,4 +308,4 @@ CCDPositions:
     NumRows:                         [4510, 4510, 4510, 4510]       # Number of rows on the CCD [pixels] (including non-exposed ones)
     FirstRowForNormalCamera:         [0, 0, 0, 0]                   # The complete CCDs are active/illuminated for the Normal Camera's
     FirstRowForFastCamera:           [2255, 2255, 2255, 2255]       # Only the upper half of the CCDs is active/illuminated for the Fast Camera's
-
+    TimeShift:                       [0.0, 6.25, 12.5, 18.75]       # Time shift for readout w.r.t. CCD #1.  [s]

--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -153,6 +153,7 @@ CCD:
     NumColumns:                      4510            # Number of columns on the CCD [pixels]                   - use when CCDPosition = Custom
     NumRows:                         4510            # Number of rows on the CCD [pixels] (including non-exposed ones) - use when CCDPosition = Custom
     FirstRowExposed:                 0               # The index of the first row that is exposed to light [pixels]
+    TimeShift:                       0.0             # Extra time shift of the first exposure. Autoset when Position is in [1,2,3,4]. [s]
     PixelSize:                       18              # [micron]
     BFE:                                             # Brighter-fatter effect
         Range:                       2               # How far pixels can be apart and still influence each other [pixels] (use window with dimensions 2 * range + 1)
@@ -302,3 +303,5 @@ CCDPositions:
     NumRows:                         [4510, 4510, 4510, 4510]       # Number of rows on the CCD [pixels] (including non-exposed ones)
     FirstRowForNormalCamera:         [0, 0, 0, 0]                   # The complete CCDs are active/illuminated for the Normal Camera's
     FirstRowForFastCamera:           [2255, 2255, 2255, 2255]       # Only the upper half of the CCDs is active/illuminated for the Fast Camera's
+    TimeShift:                       [0.0, 6.25, 12.5, 18.75]       # Time shift for readout w.r.t. CCD #1.  [s]
+

--- a/source/DetectorWithAnalyticGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticGaussianPSF.cpp
@@ -39,16 +39,16 @@ DetectorWithAnalyticGaussianPSF::DetectorWithAnalyticGaussianPSF(ConfigurationPa
 
     if(includeFlatfield)
     {
-    		// Generate the flatfield map
+        // Generate the flatfield map
 
-    		generateFlatfieldMap();
+        generateFlatfieldMap();
     }
 
     if(includeBFE)
     {
-        	// Generate Guyonnet coefficients
+        // Generate Guyonnet coefficients
 
-        	generateGuyonnetCoefficients();
+        generateGuyonnetCoefficients();
     }
 }
 

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -248,6 +248,22 @@ void Simulation::configure(ConfigurationParameters &configParams)
     useDetectorNominalTemperature   = configParams.getString("CCD/Temperature") == "Nominal";
     sendImagettesToClient           = configParams.getBoolean("ControlTcpConnection/SendImagettesToClients");
     getWindowPositionFromServer     = configParams.getBoolean("ControlTcpConnection/GetWindowPositionsFromServer");
+
+    // The readout of different CCDs are shifted in time because of the power budget.
+    // Find out the right time shift.
+
+    string ccdPosition              = configParams.getString("CCD/Position");
+    if (ccdPosition == "Custom")
+    {
+        timeShift = configParams.getDouble("CCD/TimeShift");
+    }
+    else
+    {
+        int index = stoi(ccdPosition) - 1;   // Position are named  [1, 2, 3, 4] while the index into vector starts at 0
+        timeShift = configParams.getDoubleAt("CCDPositions/TimeShift", index);
+    }
+
+    Log.debug("Simulation: configure(): time shift for current CCD configuration: " + to_string(timeShift));
 }
 
 
@@ -447,17 +463,18 @@ void Simulation::run()
 {
     // Update the internal clock
 
-    currentTime = beginExposureNr * (exposureTime + readoutTimeBeforeNextExposure);
+    currentTime = beginExposureNr * (exposureTime + readoutTimeBeforeNextExposure) + timeShift;
 
     Log.info("Simulation: running exposures " + to_string(beginExposureNr) + " to " + to_string(beginExposureNr+numExposures-1));
 
-    // declare the imagetteNumber and set the endOfSimulation variable to false
+    // Declare the imagetteNumber and set the endOfSimulation variable to false
 
     int n = beginExposureNr;
 
     bool endOfSimulation = false;  
 
-    // continue the simulation until no more jittersteps are send from a tcp connection server
+    // Continue the simulation until no more jittersteps are send from a tcp connection server
+
     while (!endOfSimulation)
     {
         // if no jitter from network is used, end the simulation, when the max number of exposures from the yaml file is reached


### PR DESCRIPTION
Added a time shift between the CCDs. Cf Issue #401 .
This adds another configuration parameter in the section CCD in the yaml input file.
When the CCD Position is not "Custom" but either 1,2,3, or 4, the time shift is auto-set.