### PR TITLE
Fixed the same bug in Camera::getInfoForTheMostRecentExposureForStar() ...

### DIFF
--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -144,7 +144,7 @@ set<unsigned int> Camera::getAllStarIDs()
 tuple<double, double, double, double, double, double> Camera::getInfoForTheMostRecentExposureForStar(int starID)
 {
     // The detected star info is stored in a map as:   map<double, map<unsigned int, array<double, 6>>> detectedStarInfo;
-    // so that  detectedStarInfo[startTime][starID] contains the values (xFPmean, yFPmean, rowPixMean, colPixmean, sumFlux, Ndetections)
+    // so that  detectedStarInfo[startTime][starID] contains the values (xFPsum, yFPsum, rowPixSum, colPixSum, sumFlux, Ndetections)
     // In C++ maps are sorted on key values (in ascending order). To find the time stamp of the most recent exposure, 
     // we simply need to access the last element. rbegin() is a reverse-iterator, starting with the last element
 
@@ -161,10 +161,10 @@ tuple<double, double, double, double, double, double> Camera::getInfoForTheMostR
     }
     else
     {
-        double xFPmean    = detectedStarInfo[timeStamp][starID][0];
-        double yFPmean    = detectedStarInfo[timeStamp][starID][1];
-        double rowPixMean = detectedStarInfo[timeStamp][starID][2];
-        double colPixMean = detectedStarInfo[timeStamp][starID][3];
+        double xFPmean    = detectedStarInfo[timeStamp][starID][0] / detectedStarInfo[timeStamp][starID][5];
+        double yFPmean    = detectedStarInfo[timeStamp][starID][1] / detectedStarInfo[timeStamp][starID][5];
+        double rowPixMean = detectedStarInfo[timeStamp][starID][2] / detectedStarInfo[timeStamp][starID][5];
+        double colPixMean = detectedStarInfo[timeStamp][starID][3] / detectedStarInfo[timeStamp][starID][5];
         double sumFlux    = detectedStarInfo[timeStamp][starID][4];
 
         return make_tuple(timeStamp, xFPmean, yFPmean, rowPixMean, colPixMean, sumFlux);

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -945,8 +945,6 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
     
         tie(time, xFPtarget, yFPtarget, rowTarget, colTarget, fluxTarget) = camera.getInfoForTheMostRecentExposureForStar(starID);
 
-        Log.debug(to_string(starID) + ": " + to_string(rowTarget) + ", " + to_string(colTarget) + ", " + to_string(fluxTarget));
-
         inputFluxTarget.at(starID).at(zeroBasedExposureNr) = fluxTarget;
 
         // If this is the first exposure, or it's already 2 weeks ago that the mask was updated,
@@ -983,12 +981,12 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
             tie(begin, end) = camera.getInfoForTheMostRecentExposureForAllStars();
             for (auto it = begin; it != end; it++)
             {
-                if (it->first == starID) continue;            // A star is never its own contaminant 
-                double xFPcont =  (it->second)[0];            // [mm]
-                double yFPcont =  (it->second)[1];            // [mm]
-                double rowCont =  (it->second)[2];            // [pix]
-                double colCont =  (it->second)[3];            // [pix]
-                double fluxCont = (it->second)[4];            // [photons/exposure]
+                if (it->first == starID) continue;                        // A star is never its own contaminant 
+                double xFPcont =  (it->second)[0] / (it->second)[5];      // [mm]
+                double yFPcont =  (it->second)[1] / (it->second)[5];      // [mm]
+                double rowCont =  (it->second)[2] / (it->second)[5];      // [pix]
+                double colCont =  (it->second)[3] / (it->second)[5];      // [pix]
+                double fluxCont = (it->second)[4];                        // [photons/exposure]
 
                 Log.debug(to_string(it->first) + ": " + to_string(rowCont) + ", " + to_string(colCont) + ", " + to_string(fluxCont));
 
@@ -1005,8 +1003,8 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
                 numContaminants++;
             }
 
-           Log.debug("Detector::applyPhotometry: Found " + to_string(numContaminants) + " contaminants for star ID " + to_string(starID));
-           Log.debug("Detector::applyPhotometry: selecting which pixels belong to the mask");
+            Log.debug("Detector::applyPhotometry: Found " + to_string(numContaminants) + " contaminants for star ID " + to_string(starID));
+            Log.debug("Detector::applyPhotometry: selecting which pixels belong to the mask");
 
             // For the mask of our target will only consider a 7x7 area around the barycenter. Get the boundaries of that area.
 
@@ -1019,6 +1017,7 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
 
             arma::Mat<float> NSRmap(numRowsPixelMap, numColumnsPixelMap, arma::fill::zeros); 
             arma::Mat<float> varianceMap(numRowsPixelMap, numColumnsPixelMap, arma::fill::zeros);
+
             vector<double> flatNSRmap;   
             for (int irow = minRow; irow <= maxRow; irow++)
             {
@@ -1097,6 +1096,7 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
             // Update the exposure nr of this mask update to the current exposure number
 
             exposureNrOfMaskUpdate.at(starID).push_back(exposureNr);
+
         }
         else
         {


### PR DESCRIPTION
and in DetectorWithAnalyticNonGaussianPSF::applyPhotometry().

DetectedStarInfo contains the sum of the coordindates, not yet the mean, so it's necessary to divide by the number of detections.