### PR TITLE
Spectral Dependency for Emitted Flux, Transmission & Quantum Efficiency

### DIFF
--- a/include/CameraSpectral.h
+++ b/include/CameraSpectral.h
@@ -34,13 +34,19 @@ class CameraSpectral : public Camera
 
     protected:
 
+        void getParameters(ConfigurationParameters &configParam);
+
     private:
+
+        SpectralDependenceUtility *Spectral;
 
         double referenceWavelength;
         int binnumber;
         double lowerWavelength;
         double binwidth;
-        vector<double> transmissionEfficiencySpectral;
+        vector<double> QESpectral;
+        double meanQE;
+        bool useQE;
 
         
 };

--- a/include/CameraSpectral.h
+++ b/include/CameraSpectral.h
@@ -1,16 +1,6 @@
 #ifndef CAMERASPECTRAL_H
 #define CAMERASPECTRAL_H
 
-#include <string>
-#include <cmath>
-#include <vector>
-#include <algorithm>
-#include <map>
-#include <array>
-#include <tuple>
-
-#include "armadillo"
-
 #include "Camera.h"
 #include "SpectralDependenceUtility.h"
 

--- a/include/CameraSpectral.h
+++ b/include/CameraSpectral.h
@@ -1,0 +1,50 @@
+#ifndef CAMERASPECTRAL_H
+#define CAMERASPECTRAL_H
+
+#include <string>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+#include <map>
+#include <array>
+#include <tuple>
+
+#include "armadillo"
+
+#include "Camera.h"
+#include "SpectralDependenceUtility.h"
+
+
+using namespace std;
+
+
+class Detector;  // forward declaration
+
+typedef map<unsigned int, array<double, 6>>::iterator starInfoIterator;
+
+
+class CameraSpectral : public Camera
+{
+    public:
+
+        CameraSpectral(ConfigurationParameters &configParam, HDF5File &hdf5File, Platform &platform, Telescope &telescope, Sky &sky);
+        virtual ~CameraSpectral(){};
+
+        virtual void exposeDetector(Detector &detector, double startTime, double exposureTime, double readoutTimeBeforeNextExposure);
+
+    protected:
+
+    private:
+
+        double referenceWavelength;
+        int binnumber;
+        double lowerWavelength;
+        double binwidth;
+        vector<double> transmissionEfficiencySpectral;
+
+        
+};
+
+
+
+#endif

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -12,6 +12,7 @@
 #include "NominalTemperature.h"
 
 #include "Camera.h"
+#include "CameraSpectral.h"
 #include "Telescope.h"
 #include "Platform.h"
 #include "Sky.h"
@@ -92,6 +93,8 @@ class Simulation
 
         bool sendImagettesToClient;
         bool getWindowPositionFromServer;
+
+        bool useStellarSpectra;
 
 };
 

--- a/include/Sky.h
+++ b/include/Sky.h
@@ -49,7 +49,9 @@ class Sky
         void aberrateSelectedStarPositions(Platform &platform, string aberrationCorrectionType, double startTime, double timeMiddle);
         tuple<unsigned int, double, double, double> getSelectedStar(unsigned int n);
 
-        tuple<double, double, double> getInfoOfStarWithID(unsigned int starID);
+        tuple<double, double, double, double> getInfoOfStarWithID(unsigned int starID);
+
+        double getSelectedStarTemp(unsigned int n);
 
 
         double zodiacalFlux(double RA, double dec, double lambda1, double lambda2);
@@ -69,14 +71,15 @@ class Sky
 
     private:
 
-        map<unsigned int, tuple<double, double, double>> starDB;    // star database: starDB[stardID] contains (RA, dec, Vmag), 
-                                                                    // with (RA, dec) in radians, and Vmag = Johnson V magnitude,
-                                                                    // and starID the star identification number.
+        map<unsigned int, tuple<double, double, double, double>> starDB;    // star database: starDB[stardID] contains (RA, dec, Vmag, T), 
+                                                                            // with (RA, dec) in radians, and Vmag = Johnson V magnitude, T in K,
+                                                                            // and starID the star identification number.
        
         vector<unsigned int> selectedStarID;  // IDs of the stars selected with selectStarsWithinRadiusFrom()
         vector<double> selectedRA;            //      Corresponding selected Right Ascension [rad]
         vector<double> selectedDec;           //      Corresponding Declination              [rad]
         vector<double> selectedVmag;          //      Corresponding Johnson V magnitude
+        vector<double> selectedTemp;          //      Corresponding Stellar Temperature      [K]
 
         vector<unsigned int> selectedVariableStars;    // Indices of those selected stars that have an entry in deltaMagnitude.
 
@@ -86,6 +89,8 @@ class Sky
         TabulatedFunction<vector<double>> tabfunction;
 
         void locate(double x, const double *array, int N, int &index);
+
+        bool fileHasTemp;  // Does the star catalogue contain stellar temperature?
 
 };
 

--- a/include/SpectralDependenceUtility.h
+++ b/include/SpectralDependenceUtility.h
@@ -20,7 +20,17 @@ class SpectralDependenceUtility
         int binnumber;
         double lowerWavelength;
         double binwidth;
-        vector<double> transmissionEfficiencySpectral;
+        vector<double> transmissionEfficiencySpectralBOL;
+        vector<double> transmissionEfficiencySpectralEOL;
+        vector<double> QESpectral;
+
+        bool useQE;
+        double meanQE;
+        
+        bool fileHasTemp;
+        double missionDuration;
+
+        vector<double> getSpectralTransmissionEfficiency(double time);
 
     protected:
 

--- a/include/SpectralDependenceUtility.h
+++ b/include/SpectralDependenceUtility.h
@@ -1,0 +1,36 @@
+#ifndef SPECTRALDEPENDENCEUTILITY_H
+#define SPECTRALDEPENDENCEUTILITY_H
+
+#include "ConfigurationParameters.h"
+#include "armadillo"
+
+// This class gets needed information to run PlatoSIm spectrally dependent
+
+class SpectralDependenceUtility
+{
+    
+    public:
+
+        SpectralDependenceUtility(ConfigurationParameters &configParams);
+
+        ~SpectralDependenceUtility() {};
+
+        bool useStellarSpectra;
+        double referenceWavelength;
+        int binnumber;
+        double lowerWavelength;
+        double binwidth;
+        vector<double> transmissionEfficiencySpectral;
+
+    protected:
+
+
+    private:
+
+        virtual void configure(ConfigurationParameters &configParams);
+
+};
+
+
+
+#endif

--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -52,8 +52,8 @@ Telescope:
 
     LightCollectingArea:             113.1           # Effective area of 1 telescope [cm^2]
     TransmissionEfficiency:
-        BOL:                         0.8135          # Beginning of Life value in [0,1]
-        EOL:                         0.7945          # End of Life value in [0,1]
+        BOL:                         1. #0.8135          # Beginning of Life value in [0,1]
+        EOL:                         1. #0.7945          # End of Life value in [0,1]
     UseDrift:                        no              # yes or no. If no, ignore everything below.
     UseDriftFromFile:                no              # yes or no. If yes: ignore RMS and timescale below
     DriftYawRms:                     2.0             # RMS of thermo-elastic drift in yaw [arcsec]
@@ -285,6 +285,15 @@ ControlTcpConnection:
 
     WindowPositionSocketTimeout:    100  # seconds
     JitterSocketTimeout:            100  # seconds
+
+
+SpectralDependency:
+
+    GenerateFluxBasedOnTemperature: yes               # yes or no
+    SpectralBinWidth:               50               # in [nm]
+    LowerWavelengthLimit:           500              # in [nm]
+    NumberOfSpectralBins:           11               # integer
+    TransmissionEfficiencySpectral:         [1,1,1,1,1,1,1,1,1,1,1]
 
 
 # ----- DO NOT MAKE CHANGES BELOW THIS LINE -----

--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -52,8 +52,8 @@ Telescope:
 
     LightCollectingArea:             113.1           # Effective area of 1 telescope [cm^2]
     TransmissionEfficiency:
-        BOL:                         1. #0.8135          # Beginning of Life value in [0,1]
-        EOL:                         1. #0.7945          # End of Life value in [0,1]
+        BOL:                         0.8135          # Beginning of Life value in [0,1]
+        EOL:                         0.7945          # End of Life value in [0,1]
     UseDrift:                        no              # yes or no. If no, ignore everything below.
     UseDriftFromFile:                no              # yes or no. If yes: ignore RMS and timescale below
     DriftYawRms:                     2.0             # RMS of thermo-elastic drift in yaw [arcsec]
@@ -289,11 +289,14 @@ ControlTcpConnection:
 
 SpectralDependency:
 
-    GenerateFluxBasedOnTemperature: yes               # yes or no
-    SpectralBinWidth:               50               # in [nm]
-    LowerWavelengthLimit:           500              # in [nm]
-    NumberOfSpectralBins:           11               # integer
-    TransmissionEfficiencySpectral:         [1,1,1,1,1,1,1,1,1,1,1]
+    StarCatalogueHasTemp:           no              # Whether or not the star catalogue has a comun for stellar temperature (RA/DEC/Mag/T?/ID?)
+    GenerateFluxBasedOnTemperature: yes              # [yes/no] Whether or not to use stellar Temperature to respect spectral dependency of PLATO - if 'yes' give info below
+    SpectralBinWidth:               50               # in [nm], width of an individual spectral bin to approximate the spectrum
+    LowerWavelengthLimit:           500              # in [nm], lower limit where to start the spectral bins
+    NumberOfSpectralBins:           11               # Total number of spectral bins
+    TransmissionEfficiencySpectralBOL: [0.831, 0.847, 0.845, 0.844, 0.850, 0.852, 0.854, 0.855, 0.855, 0.856, 0.857]  # Transmission Efficiency in every spectral bin BOL
+    TransmissionEfficiencySpectralEOL: [0.831, 0.847, 0.845, 0.844, 0.850, 0.852, 0.854, 0.855, 0.855, 0.856, 0.857]  # Transmission Efficiency in every spectral bin EOL
+    QuantumEfficiencySpectral:         [0.737, 0.807, 0.877, 0.867, 0.858, 0.757, 0.655, 0.485, 0.314, 0.165, 0.062]  # QE in every spectral bin - only applied in using QE
 
 
 # ----- DO NOT MAKE CHANGES BELOW THIS LINE -----

--- a/source/CameraSpectral.cpp
+++ b/source/CameraSpectral.cpp
@@ -11,16 +11,39 @@
 
 CameraSpectral::CameraSpectral(ConfigurationParameters &configParam, HDF5File &hdf5file, Platform &platform, Telescope &telescope, Sky &sky) : Camera(configParam, hdf5file, platform, telescope, sky)
 {
-    SpectralDependenceUtility Spectral(configParam);
-    binnumber = Spectral.binnumber;
-    binwidth = Spectral.binwidth;
-    lowerWavelength = Spectral.lowerWavelength;
-    referenceWavelength = Spectral.referenceWavelength;
-    transmissionEfficiencySpectral = Spectral.transmissionEfficiencySpectral;
+    Spectral = new SpectralDependenceUtility(configParam);
+    getParameters(configParam);
 }
 
 
 
+/**
+ *
+ */
+void CameraSpectral::getParameters(ConfigurationParameters &configParam)
+{
+    //SpectralDependenceUtility Spectral(configParam);
+    binnumber = Spectral->binnumber;
+    binwidth = Spectral->binwidth;
+    lowerWavelength = Spectral->lowerWavelength;
+    referenceWavelength = Spectral->referenceWavelength;
+    useQE = Spectral->useQE;
+    if (useQE)
+    {
+        QESpectral = Spectral->QESpectral;
+        meanQE = Spectral->meanQE;
+    }
+    else
+    {
+        QESpectral.assign(binnumber,1.); 
+        meanQE = 1.;
+    }
+}
+
+
+/**
+ *
+ */
 void CameraSpectral::exposeDetector(Detector &detector, double startTime, double exposureTime, double readoutTimeBeforeNextExposure)
 {
     // Get the value for the degrading TransmissionEfficiency parameter at the startTime of this exposure
@@ -28,6 +51,8 @@ void CameraSpectral::exposeDetector(Detector &detector, double startTime, double
     double transmissionEfficiency = telescope.getTransmissionEfficiency(startTime);
 
     Log.debug("Camera: TransmissionEfficiency at time "+to_string(startTime)+" is "+to_string(transmissionEfficiency));
+
+    vector<double> transmissionEfficiencySpectral = Spectral->getSpectralTransmissionEfficiency(startTime);
 
 
     // Get the focal plane coordinates of the center and the corners of the subfield (in [mm]).
@@ -120,7 +145,6 @@ void CameraSpectral::exposeDetector(Detector &detector, double startTime, double
     // fluxOfV0Star is the photon flux [photons/s/m^2/nm] for a V=0 G2V-star.
     // Units of fluxFactor: [photons/s]
   
-    //#const double fluxFactor = fluxOfV0Star * throughputBandwidth * transmissionEfficiency * telescope.getLightCollectingArea(); 
 
     const double hc = Constants::CLIGHT * Constants::HPLANCK * 1.e9;
     const double referenceFlux = fluxOfV0Star * hc / referenceWavelength; 
@@ -139,7 +163,7 @@ void CameraSpectral::exposeDetector(Detector &detector, double startTime, double
         double wavelength = lowerWavelength + i*binwidth + binwidth/2;
         double Ephoton = hc / wavelength;
         photonEnergies.push_back(Ephoton);
-        double fluxFactorWave = transmissionEfficiencySpectral[i] * pow(referenceWavelength / wavelength, 5) / Ephoton;
+        double fluxFactorWave = transmissionEfficiencySpectral[i] * pow(referenceWavelength / wavelength, 5);
         wavePrefactors.push_back(fluxFactorWave);
     } 
 
@@ -171,7 +195,7 @@ void CameraSpectral::exposeDetector(Detector &detector, double startTime, double
             double RA, dec, Vmag;
 
             tie(starID, RA, dec, Vmag) = sky.getSelectedStar(n);
-            double tempStar = 5700;
+            double tempStar = sky.getSelectedStarTemp(n);
             
             double Xmm, Ymm;
             tie(Xmm, Ymm) = skyToFocalPlaneCoordinates(RA, dec);
@@ -192,7 +216,7 @@ void CameraSpectral::exposeDetector(Detector &detector, double startTime, double
             for (int i=0; i<binnumber; i++)
             {
             double tempFactor = (exp(hc/(referenceWavelength*Constants::KBOLTZMANN*tempStar)) - 1) / (exp(photonEnergies[i]/(Constants::KBOLTZMANN*tempStar)) - 1);
-            flux += floor(fluxFactor * wavePrefactors[i] * pow(10.0, -0.4 * Vmag) * timeStep * tempFactor);
+            flux += floor(fluxFactor * wavePrefactors[i] * pow(10.0, -0.4 * Vmag) * timeStep * tempFactor) * QESpectral[i] / meanQE;
             } 
 
             // Let the detector add the flux to the appropriate pixel. 

--- a/source/CameraSpectral.cpp
+++ b/source/CameraSpectral.cpp
@@ -1,0 +1,307 @@
+#include "CameraSpectral.h"
+
+/**
+ * \brief      Constructor
+ *
+ * \param configParam   Configuration parameters for the Camera
+ * \param hdf5file      HFD5 file to write the camera information to
+ * \param telescope     Telescope on which the camera is mounted on
+ * \param sky           Sky object to query which stars we are seeing
+ */
+
+CameraSpectral::CameraSpectral(ConfigurationParameters &configParam, HDF5File &hdf5file, Platform &platform, Telescope &telescope, Sky &sky) : Camera(configParam, hdf5file, platform, telescope, sky)
+{
+    SpectralDependenceUtility Spectral(configParam);
+    binnumber = Spectral.binnumber;
+    binwidth = Spectral.binwidth;
+    lowerWavelength = Spectral.lowerWavelength;
+    referenceWavelength = Spectral.referenceWavelength;
+    transmissionEfficiencySpectral = Spectral.transmissionEfficiencySpectral;
+}
+
+
+
+void CameraSpectral::exposeDetector(Detector &detector, double startTime, double exposureTime, double readoutTimeBeforeNextExposure)
+{
+    // Get the value for the degrading TransmissionEfficiency parameter at the startTime of this exposure
+
+    double transmissionEfficiency = telescope.getTransmissionEfficiency(startTime);
+
+    Log.debug("Camera: TransmissionEfficiency at time "+to_string(startTime)+" is "+to_string(transmissionEfficiency));
+
+
+    // Get the focal plane coordinates of the center and the corners of the subfield (in [mm]).
+    // To compute the diagonal length of the subfield, we only need the lower left (X00, Y00)
+    // and the upper right (X11, Y11) corner of the subfield.
+
+    double centerXmm, centerYmm;
+    tie(centerXmm, centerYmm) = detector.getFocalPlaneCoordinatesOfSubfieldCenter();
+
+    double corner00Xmm, corner00Ymm, corner11Xmm, corner11Ymm, dummy;
+    tie(corner00Xmm, corner00Ymm, dummy, dummy, corner11Xmm, corner11Ymm, dummy, dummy) = detector.getFocalPlaneCoordinatesOfSubfieldCorners();
+
+    // Convert the undistorted [mm] to distorted [mm] focal plane coordinates
+
+    if (includeFieldDistortion)
+    {
+        Log.info("Camera: including field distortion");
+
+        tie(centerXmm, centerYmm) = distortedToUndistortedFocalPlaneCoordinates(centerXmm, centerYmm);
+        tie(corner00Xmm, corner00Ymm) = distortedToUndistortedFocalPlaneCoordinates(corner00Xmm, corner00Ymm);
+        tie(corner11Xmm, corner11Ymm) = distortedToUndistortedFocalPlaneCoordinates(corner11Xmm, corner11Ymm);
+    }
+
+    Log.debug("Camera: center of subfield at (Xmm, Ymm) = (" + to_string(centerXmm) + ", " + to_string(centerYmm) + ") mm");
+    Log.debug("Camera: lower left corner of subfield at (Xmm, Ymm) = (" + to_string(corner00Xmm) + ", " + to_string(corner00Ymm) + ") mm");
+    Log.debug("Camera: upper right corner of subfield at (Xmm, Ymm) = (" + to_string(corner11Xmm) + ", " + to_string(corner11Ymm) + ") mm");
+
+
+    // Convert the focal plane coordinates [mm] to (alpha, delta) equatorial sky coordinates [rad]
+
+    double centerRA, centerDec;
+    tie(centerRA, centerDec) = focalPlaneToSkyCoordinates(centerXmm, centerYmm);
+
+    double corner00RA, corner00Dec;
+    tie(corner00RA, corner00Dec) = focalPlaneToSkyCoordinates(corner00Xmm, corner00Ymm);
+
+    double corner11RA, corner11Dec;
+    tie(corner11RA, corner11Dec) = focalPlaneToSkyCoordinates(corner11Xmm, corner11Ymm);
+
+    Log.debug("Camera: center of subfield at (alpha, delta) = (" + to_string(rad2deg(centerRA)) + ", " + to_string(rad2deg(centerDec)) + ") deg");
+    Log.debug("Camera: lower left corner of subfield at (alpha, delta) = (" + to_string(rad2deg(corner00RA)) + ", " + to_string(rad2deg(corner00Dec)) + ") deg");
+    Log.debug("Camera: upper right corner of subfield at (alpha, delta) = (" + to_string(rad2deg(corner11RA)) + ", " + to_string(rad2deg(corner11Dec)) + ") deg");
+
+
+    // Compute the angular distance on the sky between the lower left and the upper right corner
+    // of the subfield, to estimate the "radius" of the subfield.
+
+    SkyCoordinates skyCoordinates00(corner00RA, corner00Dec, Angle::radians);
+    SkyCoordinates skyCoordinates11(corner11RA, corner11Dec, Angle::radians);
+    
+    double radius = angularDistanceBetween(skyCoordinates00, skyCoordinates11, Angle::radians) / 2.0;
+
+    Log.debug("Camera: semi-diagonal of subfield = " + to_string(rad2deg(radius)) + " deg");
+
+
+    // Get a catalog of stars that fall on the subfield. Take the radius a bit larger so that the 
+    // queried area includes possible small shifts of the projected subfield because of jitter.
+
+    const unsigned long Nstars = sky.selectStarsWithinRadiusFrom(centerRA, centerDec, radius * 1.1, Angle::radians);
+
+    Log.info("Camera: Found " + to_string(Nstars) + " stars on and near the subfield");  
+
+    if (includeAberrationCorrection)
+    {
+        Log.info("Camera: applying " + aberrationCorrectionType + " aberration correction to the selected stars in the subfield.");
+
+        // The time at the middle of the time series is the time when the Sun is defined to be 180 degrees away from platform pointing
+
+        double timeMiddle = numExposures * (exposureTime + readoutTimeBeforeNextExposure) / 2.0;
+
+        // Get the apparent position of the stars, i.e. apply the differential aberration correction to
+        // all the star positions in this starCatalog.
+
+        // We do this calcuation only once per exposure as the effect is negligible within the exposure time
+    
+        sky.aberrateSelectedStarPositions(platform, aberrationCorrectionType, startTime, timeMiddle);
+    }
+
+
+    // If the telescope and/or platform show small variations (e.g. due to jitter) during the exposure,
+    // the exposure time is split up in many small intervals, to track the effect of these variations
+    // on the exposure. The largest time interval for which the variations can still be reliably tracked
+    // is called the heartbeatInterval. The time step used should be either the heartbeat interval or the
+    // expsosure time whatever is smallest. 
+
+    double timeStep = min(telescope.getHeartbeatInterval(), exposureTime);
+
+
+    // Later on we will have to convert from magnitudes to fluxes. Precompute a constant prefactor.
+    // fluxOfV0Star is the photon flux [photons/s/m^2/nm] for a V=0 G2V-star.
+    // Units of fluxFactor: [photons/s]
+  
+    //#const double fluxFactor = fluxOfV0Star * throughputBandwidth * transmissionEfficiency * telescope.getLightCollectingArea(); 
+
+    const double hc = Constants::CLIGHT * Constants::HPLANCK * 1.e9;
+    const double referenceFlux = fluxOfV0Star * hc / referenceWavelength; 
+    const double fluxFactor = referenceFlux * binwidth * telescope.getLightCollectingArea();
+
+    vector<double> wavePrefactors;
+    wavePrefactors.reserve(binnumber);
+    wavePrefactors.clear();
+
+    vector<double> photonEnergies;
+    photonEnergies.reserve(binnumber);
+    photonEnergies.clear();
+
+    for (int i=0; i<binnumber; i++)
+    {
+        double wavelength = lowerWavelength + i*binwidth + binwidth/2;
+        double Ephoton = hc / wavelength;
+        photonEnergies.push_back(Ephoton);
+        double fluxFactorWave = transmissionEfficiencySpectral[i] * pow(referenceWavelength / wavelength, 5) / Ephoton;
+        wavePrefactors.push_back(fluxFactorWave);
+    } 
+
+    // Update the internal clock
+
+    internalTime = startTime;
+
+    // Take the flux of point sources (stars) into account.
+    // Break up the exposure time in small intervals (hearbeat intervals) to track jitter while exposing.
+
+    while (internalTime < startTime + exposureTime)
+    {
+        // Update the time-dependent parameters (if any) of some classes to to their value at the current time. 
+
+        this->updateParameters(internalTime);
+        telescope.updateParameters(internalTime);
+        detector.updateParameters(internalTime);
+        sky.updateParameters(internalTime);
+
+        // Loop over all stars in the catalog, and add their flux to the subfield
+
+        unsigned int NstarsInSubfield = 0;
+
+        for (unsigned int n = 0; n < Nstars; n++)
+        {
+            // Compute the focal plane coordinates (in [mm]) of this particular star
+           
+            unsigned long starID;
+            double RA, dec, Vmag;
+
+            tie(starID, RA, dec, Vmag) = sky.getSelectedStar(n);
+            double tempStar = 5700;
+            
+            double Xmm, Ymm;
+            tie(Xmm, Ymm) = skyToFocalPlaneCoordinates(RA, dec);
+
+            // If required, include field distortion
+
+            if (includeFieldDistortion)
+            {
+                tie(Xmm, Ymm) = undistortedToDistortedFocalPlaneCoordinates(Xmm, Ymm);
+            }
+
+            // Compute the flux [photons] of this star
+            // Photons are always an integer number, so round down.
+            // To do this, calculate the spectrally correct transmissionEfficiency and flux fraction binwise
+
+            double flux = 0.;
+
+            for (int i=0; i<binnumber; i++)
+            {
+            double tempFactor = (exp(hc/(referenceWavelength*Constants::KBOLTZMANN*tempStar)) - 1) / (exp(photonEnergies[i]/(Constants::KBOLTZMANN*tempStar)) - 1);
+            flux += floor(fluxFactor * wavePrefactors[i] * pow(10.0, -0.4 * Vmag) * timeStep * tempFactor);
+            } 
+
+            // Let the detector add the flux to the appropriate pixel. 
+            // Detector.flux() returns the pixel coordinates to which the flux was added.
+
+            bool isInSubfield;
+            double rowPix, colPix;    // subfield (not CCD) pixel coordinates
+
+            tie(isInSubfield, rowPix, colPix) = detector.addFlux(Xmm, Ymm, flux);
+
+            // If the star is indeed in the subfield, collect the following information to later write to HDF5
+            //    1) average (Xmm, Ymm) coordinates of the star during the exposure                   [mm]
+            //    2) average (row, col) pixel coordinates of the star on the CCD during the exposure  [pix]
+            //    3) the total number of photons gathered of this star during the exposure            [photons]
+            //    4) the total number of times that the star was in the subfield during the exposure
+            //
+            // Note: Due to jitter, the star can move in and out the subfield during the exposure
+
+            if (isInSubfield)
+            {
+                NstarsInSubfield++;
+
+                // If this is the first time we encounter this startTime, initialise the information
+
+                if (detectedStarInfo.find(startTime) == detectedStarInfo.end())
+                {
+                    detectedStarInfo[startTime][starID] = {{Xmm, Ymm, rowPix, colPix, flux, 1.0}};
+                }
+                else
+                {
+                    // If this is the first time that we encounter this star ID associated with this startTime,
+                    // initialise the information. If not, just update the info.
+
+                    if (detectedStarInfo[startTime].find(starID) == detectedStarInfo[startTime].end())
+                    {
+                        detectedStarInfo[startTime][starID] = {{Xmm, Ymm, rowPix, colPix, flux, 1.0}};
+                    }
+                    else
+                    {
+                        detectedStarInfo[startTime][starID][0] += Xmm;      // Will be used to compute average Xmm during the exposure
+                        detectedStarInfo[startTime][starID][1] += Ymm;      // Will be used to compute average Ymm during the exposure
+                        detectedStarInfo[startTime][starID][2] += rowPix;   // Will be used to compute average pixel row during the exposure
+                        detectedStarInfo[startTime][starID][3] += colPix;   // Will be used to compute average pixel column during the exposure
+                        detectedStarInfo[startTime][starID][4] += flux;     // Total flux
+                        detectedStarInfo[startTime][starID][5] += 1;        // # of times a star was on the subfield during an exposure 
+                    }
+                }
+            }
+        }
+
+        Log.debug("Camera: at time " + to_string(internalTime) + ": incremented flux of " + to_string(NstarsInSubfield) + " stars in subfield");
+
+
+        // Update the clock. Normally with 'timeStep', but if adding timeStep would overstep
+        // the total exposure time, take the small rest time instead (but update the internal time first!).
+
+        internalTime += timeStep;
+        timeStep = min(timeStep, startTime + exposureTime - internalTime);
+    }
+
+    // Take the flux of the stellar background and the zodiacal light into account. Use one value for the entire subfield.
+    // A negative value for the user given sky background value [phot/pix/s] signals that we should compute it ourselves.
+    // Note: - The output of sky.zodiacalFlux() is in [J s^{-1} m^{-2} sr^{-1} m^{-1}]
+    //       - As wavelength range we take the entire throughput band.
+    //       - Photons are always an integer number, thus round down.
+    //
+    // The small sky background contribution during the readout with open shutter is not taken into account here
+    // but in the function Detector::applyOpenShutterSmearing().
+
+    totalSkyBackground = 0.0;
+
+
+    if (userGivenSkyBackground < 0.0)
+    {
+        const double energyOfOnePhoton = Constants::CLIGHT * Constants::HPLANCK / (throughputLambdaC * 1.e-9);                // [J]
+        const double lambda1 = (throughputLambdaC - throughputBandwidth/2.0) * 1.e-9;                                         // [m]
+        const double lambda2 = (throughputLambdaC + throughputBandwidth/2.0) * 1.e-9;                                         // [m]
+    
+        const double zodiacalFlux = sky.zodiacalFlux(centerRA, centerDec, lambda1, lambda2)                                   // [phot/exposure]
+                                    * (exposureTime + readoutTimeBeforeNextExposure) * transmissionEfficiency * telescope.getLightCollectingArea()
+                                    * detector.getSolidAngleOfOnePixel(plateScale) / energyOfOnePhoton; 
+
+        const double stellarBackgroundFlux = sky.stellarBackgroundFlux(centerRA, centerDec, lambda1, lambda2)                 // [phot/exposure]
+                                             * (exposureTime + readoutTimeBeforeNextExposure) * transmissionEfficiency * telescope.getLightCollectingArea()
+                                             * detector.getSolidAngleOfOnePixel(plateScale) / energyOfOnePhoton;      
+
+
+        totalSkyBackground = floor(zodiacalFlux + stellarBackgroundFlux);
+        detector.addFlux(totalSkyBackground);
+
+        Log.debug("Camera: zodiacal flux level in subfield = " + to_string(zodiacalFlux) + " photons/pixel/exposure");
+        Log.debug("Camera: stellar background flux level in subfield = " + to_string(stellarBackgroundFlux) + " photons/pixel/exposure");
+    }
+    else
+    {
+        totalSkyBackground = floor(userGivenSkyBackground * exposureTime * transmissionEfficiency);
+        detector.addFlux(totalSkyBackground);
+
+        Log.debug("Camera: user-given sky background flux over exposure= " + to_string(userGivenSkyBackground * exposureTime) + " photons/pixel/exposure");
+    }
+
+    // Save the sky background value that we added. [photons/pix/exposure]
+
+    skyBackgroundValues.push_back(totalSkyBackground);
+
+    // Save the transmissionEfficiency value that was calculated for this exposure.
+
+    transmissionEfficiencyValues.push_back(transmissionEfficiency);
+
+    return;
+}
+

--- a/source/CameraSpectral.cpp
+++ b/source/CameraSpectral.cpp
@@ -163,7 +163,7 @@ void CameraSpectral::exposeDetector(Detector &detector, double startTime, double
         double wavelength = lowerWavelength + i*binwidth + binwidth/2;
         double Ephoton = hc / wavelength;
         photonEnergies.push_back(Ephoton);
-        double fluxFactorWave = transmissionEfficiencySpectral[i] * pow(referenceWavelength / wavelength, 5);
+        double fluxFactorWave = transmissionEfficiencySpectral[i] * pow(referenceWavelength / wavelength, 5)/Ephoton;
         wavePrefactors.push_back(fluxFactorWave);
     } 
 
@@ -215,9 +215,10 @@ void CameraSpectral::exposeDetector(Detector &detector, double startTime, double
 
             for (int i=0; i<binnumber; i++)
             {
-            double tempFactor = (exp(hc/(referenceWavelength*Constants::KBOLTZMANN*tempStar)) - 1) / (exp(photonEnergies[i]/(Constants::KBOLTZMANN*tempStar)) - 1);
-            flux += floor(fluxFactor * wavePrefactors[i] * pow(10.0, -0.4 * Vmag) * timeStep * tempFactor) * QESpectral[i] / meanQE;
+                double tempFactor = (exp(hc/(referenceWavelength*Constants::KBOLTZMANN*tempStar)) - 1) / (exp(photonEnergies[i]/(Constants::KBOLTZMANN*tempStar)) - 1);
+                flux += floor(fluxFactor * wavePrefactors[i] * pow(10.0, -0.4 * Vmag) * timeStep * tempFactor) * QESpectral[i] / meanQE;
             } 
+
 
             // Let the detector add the flux to the appropriate pixel. 
             // Detector.flux() returns the pixel coordinates to which the flux was added.

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -161,7 +161,15 @@ Simulation::Simulation(string inputFilename, string outputFilename)
     platform   = new Platform(configParams, *hdf5File, *jitterGenerator);
     telescope  = new Telescope(configParams, *hdf5File, *platform, *driftGenerator);
     sky        = new Sky(configParams);
-    camera     = new Camera(configParams, *hdf5File, *platform, *telescope, *sky);
+
+    if (useStellarSpectra)
+    {
+        camera = new CameraSpectral(configParams, *hdf5File, *platform, *telescope, *sky);
+    }
+    else
+    {
+        camera = new Camera(configParams, *hdf5File, *platform, *telescope, *sky);
+    }
 
 
     // Depending on how the PSF is computed (analytically or pre-mapped) the Detector object is different.
@@ -252,6 +260,7 @@ void Simulation::configure(ConfigurationParameters &configParams)
     useDetectorNominalTemperature   = configParams.getString("CCD/Temperature") == "Nominal";
     sendImagettesToClient           = configParams.getBoolean("ControlTcpConnection/SendImagettesToClients");
     getWindowPositionFromServer     = configParams.getBoolean("ControlTcpConnection/GetWindowPositionsFromServer");
+    useStellarSpectra               = configParams.getBoolean("SpectralDependency/GenerateFluxBasedOnTemperature");
 
     // The readout of different CCDs are shifted in time because of the power budget.
     // Find out the right time shift.

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -577,6 +577,7 @@ void Simulation::writeStarCatalogToHDF5()
     vector<double> colPix(Nstars);
     vector<double> xFPmm(Nstars);
     vector<double> yFPmm(Nstars);
+    vector<double> temp(Nstars);
 
     double xFPrad, yFPrad;
 
@@ -586,7 +587,7 @@ void Simulation::writeStarCatalogToHDF5()
         for (auto starID: allStarIDs)
         {
             starIDs[k] = starID;
-            tie(RA[k], dec[k], Vmag[k]) = sky->getInfoOfStarWithID(starID);  // RA & dec returned in radians!
+            tie(RA[k], dec[k], Vmag[k], temp[k]) = sky->getInfoOfStarWithID(starID);  // RA & dec returned in radians!
             const bool useInitialOrientation = true;
             tie(xFPmm[k], yFPmm[k]) = camera->skyToFocalPlaneCoordinates(RA[k], dec[k], useInitialOrientation);
             
@@ -606,6 +607,7 @@ void Simulation::writeStarCatalogToHDF5()
         hdf5File->writeArray("StarCatalog/", "RA",      RA.data(), RA.size());
         hdf5File->writeArray("StarCatalog/", "Dec",     dec.data(), dec.size());
         hdf5File->writeArray("StarCatalog/", "Vmag",    Vmag.data(), Vmag.size());
+        hdf5File->writeArray("StarCatalog/", "Temp",    temp.data(), temp.size());
         hdf5File->writeArray("StarCatalog/", "xFPmm",    xFPmm.data(), xFPmm.size());
         hdf5File->writeArray("StarCatalog/", "yFPmm",    yFPmm.data(), yFPmm.size());
         hdf5File->writeArray("StarCatalog/", "colPix",    colPix.data(), colPix.size());

--- a/source/Sky.cpp
+++ b/source/Sky.cpp
@@ -43,20 +43,26 @@ Sky::Sky(ConfigurationParameters &configParams)
             istringstream buffer(line);
             vector<double> numbers((istream_iterator<double>(buffer)), istream_iterator<double>());
             
-            // If the line contains 4 numbers then the last one is the star ID. If not, then
+            // If the line contains 4 numbers then the last one is the star ID (+1 if Temperature is present). If not, then
             // use the line number (starting from 0) as star ID.
             
             unsigned int starID;
-            if (numbers.size() == 3)
+            if (numbers.size() == 3 + fileHasTemp)
             {
                 starID = n;
             }
-            if (numbers.size() == 4)
+            if (numbers.size() == 4 + fileHasTemp)
             {
-                starID = static_cast<unsigned int>(numbers[3]);
+                starID = static_cast<unsigned int>(numbers[3 + fileHasTemp]);
             }
 
-            starDB.emplace(starID, make_tuple(numbers[0] / Angle::degrees, numbers[1] / Angle::degrees, numbers[2]));    // (starID, (RA[rad], DEC[rad], Vmag)
+            double temp = 5980;  //G0V Star temperature
+            if (fileHasTemp)
+            {
+                temp = numbers[3];
+            }
+
+            starDB.emplace(starID, make_tuple(numbers[0] / Angle::degrees, numbers[1] / Angle::degrees, numbers[2], temp));    // (starID, (RA[rad], DEC[rad], Vmag)
             n++;
         }
 
@@ -104,6 +110,7 @@ void Sky::configure(ConfigurationParameters &configParams)
     // Store the path of the general database of stars
     
     starInputfile = configParams.getAbsoluteFilename("ObservingParameters/StarCatalogFile");
+    fileHasTemp   = configParams.getBoolean("SpectralDependency/StarCatalogueHasTemp");
 
     // If there variable stars, get their time series files
     
@@ -298,8 +305,8 @@ unsigned long Sky::selectStarsWithinRadiusFrom(double RA0, double dec0, double r
     for (auto const& star: starDB)
     {
         unsigned int starID = star.first;
-        double RA, dec, Vmag;
-        tie(RA, dec, Vmag) = star.second;
+        double RA, dec, Vmag, temp;
+        tie(RA, dec, Vmag, temp) = star.second;
         double angularDistances = angularDistanceBetween(RACircleCenter, decCircleCenter, RA, dec, Angle::radians);  // [rad]
  
         if (angularDistances <= radiusCircle)
@@ -308,6 +315,7 @@ unsigned long Sky::selectStarsWithinRadiusFrom(double RA0, double dec0, double r
             selectedRA.push_back(RA);
             selectedDec.push_back(dec);
             selectedVmag.push_back(Vmag);
+            selectedTemp.push_back(temp);
 
             // Also keep track of which selected stars are variable. Saves us many search loops afterwards.
             // selectedVariableStars contains the _indices_ (of selected*) of those stars that are variable.
@@ -418,8 +426,8 @@ void Sky::aberrateSelectedStarPositions(Platform &platform, string aberrationCor
 
     for (unsigned int n = 0; n < selectedStarID.size(); ++n)
     {
-        double raStar, decStar, Vmag;
-        tie(raStar, decStar, Vmag) = starDB[selectedStarID[n]];       // ra & dec in [rad]
+        double raStar, decStar, Vmag, temp;
+        tie(raStar, decStar, Vmag, temp) = starDB[selectedStarID[n]];       // ra & dec in [rad]
 
         double lambdaStar, betaStar;
         equatorial2ecliptic(raStar, decStar, lambdaStar, betaStar);
@@ -505,6 +513,27 @@ tuple<unsigned int, double, double, double> Sky::getSelectedStar(unsigned int n)
 
 
 
+/**
+ * \brief Return temperature of selected Star
+ *
+ * \detail is separated from getSelectedStar to declutter run without spectral dependency
+ *
+ * \param n: 0 <= n < number of selected stars 
+ *
+ * \return selectedTemp of starID
+ */
+double Sky::getSelectedStarTemp(unsigned int n)
+{
+    if (n > selectedStarID.size()-1)
+    {
+        throw IllegalArgumentException("Sky::getSelectedStarTemp(): star number is larger than " + to_string(selectedStarID.size()-1));
+    }
+    else
+    {
+        return selectedTemp[n];
+    }
+}
+
 
 
 
@@ -517,7 +546,7 @@ tuple<unsigned int, double, double, double> Sky::getSelectedStar(unsigned int n)
  *
  */
 
-tuple<double, double, double> Sky::getInfoOfStarWithID(unsigned int starID)
+tuple<double, double, double, double> Sky::getInfoOfStarWithID(unsigned int starID)
 {
     if (starDB.count(starID) == 0)
     {

--- a/source/SpectralDependenceUtility.cpp
+++ b/source/SpectralDependenceUtility.cpp
@@ -1,0 +1,37 @@
+#include "SpectralDependenceUtility.h"
+
+
+
+/**
+ * \brief constructor of the SpectralDependencyUtility class
+ */
+SpectralDependenceUtility::SpectralDependenceUtility(ConfigurationParameters &configParams)
+{
+    configure(configParams);
+}
+
+
+
+/**
+ * \brief get needed variables from the input file
+ *        
+ */
+void SpectralDependenceUtility::configure(ConfigurationParameters &configParams)
+{
+
+    useStellarSpectra               = configParams.getBoolean("SpectralDependency/GenerateFluxBasedOnTemperature");
+    referenceWavelength             = configParams.getDouble("Camera/ThroughputLambdaC");
+    binnumber                       = configParams.getInteger("SpectralDependency/NumberOfSpectralBins");
+    lowerWavelength                 = configParams.getDouble("SpectralDependency/LowerWavelengthLimit");
+    binwidth                        = configParams.getDouble("SpectralDependency/SpectralBinWidth");
+    transmissionEfficiencySpectral  = configParams.getDoubleVector("SpectralDependency/TransmissionEfficiencySpectral");
+
+    if (transmissionEfficiencySpectral.size() != binnumber)
+    {
+        string errorMessage = "Spectral: number of transmission values different from number of wavelength bins.";
+        Log.error(errorMessage);
+        throw IllegalArgumentException(errorMessage);
+    }
+
+}
+

--- a/source/SpectralDependenceUtility.cpp
+++ b/source/SpectralDependenceUtility.cpp
@@ -19,19 +19,50 @@ SpectralDependenceUtility::SpectralDependenceUtility(ConfigurationParameters &co
 void SpectralDependenceUtility::configure(ConfigurationParameters &configParams)
 {
 
-    useStellarSpectra               = configParams.getBoolean("SpectralDependency/GenerateFluxBasedOnTemperature");
-    referenceWavelength             = configParams.getDouble("Camera/ThroughputLambdaC");
-    binnumber                       = configParams.getInteger("SpectralDependency/NumberOfSpectralBins");
-    lowerWavelength                 = configParams.getDouble("SpectralDependency/LowerWavelengthLimit");
-    binwidth                        = configParams.getDouble("SpectralDependency/SpectralBinWidth");
-    transmissionEfficiencySpectral  = configParams.getDoubleVector("SpectralDependency/TransmissionEfficiencySpectral");
+    useStellarSpectra                  = configParams.getBoolean("SpectralDependency/GenerateFluxBasedOnTemperature");
+    referenceWavelength                = configParams.getDouble("Camera/ThroughputLambdaC");
+    binnumber                          = configParams.getInteger("SpectralDependency/NumberOfSpectralBins");
+    lowerWavelength                    = configParams.getDouble("SpectralDependency/LowerWavelengthLimit");
+    binwidth                           = configParams.getDouble("SpectralDependency/SpectralBinWidth");
+    transmissionEfficiencySpectralBOL  = configParams.getDoubleVector("SpectralDependency/TransmissionEfficiencySpectralBOL");
+    transmissionEfficiencySpectralEOL  = configParams.getDoubleVector("SpectralDependency/TransmissionEfficiencySpectralEOL");
+    QESpectral                         = configParams.getDoubleVector("SpectralDependency/QuantumEfficiencySpectral");
 
-    if (transmissionEfficiencySpectral.size() != binnumber)
+    useQE                              = configParams.getBoolean("CCD/IncludeQuantumEfficiency");
+    fileHasTemp                        = configParams.getBoolean("SpectralDependency/StarCatalogueHasTemp");
+
+    meanQE                             = configParams.getDouble("CCD/QuantumEfficiency/MeanQuantumEfficiency");
+    missionDuration                    = configParams.getDouble("ObservingParameters/MissionDuration") * 31536000.0; // [s]
+
+    if ((transmissionEfficiencySpectralBOL.size() != binnumber) || (transmissionEfficiencySpectralEOL.size() != binnumber) || (QESpectral.size() != binnumber))
     {
-        string errorMessage = "Spectral: number of transmission values different from number of wavelength bins.";
+        string errorMessage = "Spectral: number of transmission/QE values different from number of wavelength bins.";
         Log.error(errorMessage);
         throw IllegalArgumentException(errorMessage);
     }
 
+    if (!fileHasTemp)
+    {
+        string errorMessage = "Spectral: StarCatalogue does not contain stellar temperature.";
+        Log.warning(errorMessage);
+    }
+
+}
+
+
+
+/**
+ * \brief Return the transmission efficiency of the telescope in all spectral bins (number between 0 and 1)
+ * 
+ */
+
+vector<double> SpectralDependenceUtility::getSpectralTransmissionEfficiency(double time)
+{
+    vector<double> transmission = transmissionEfficiencySpectralBOL;
+    for (int i=0; i<transmissionEfficiencySpectralBOL.size(); i++)
+    {
+       transmission[i]-= (transmissionEfficiencySpectralBOL[i] - transmissionEfficiencySpectralEOL[i]) / missionDuration * time;
+    }
+    return transmission;
 }
 


### PR DESCRIPTION
Spectral dependency for the main contributor (Total effective flux change) identified in the more resource hungry full loop variant (that includes PSF and potential for PRNU, IPRNU dependencies etc...).

The outputfile now contains the stellar temperature in the starcatalog section. Currently, no information on spectral transmission or QE is saved (could be generated out of the mean one), but could be added.

The inputfile has an additional section containing two switches:
    - Catalog contains Temperature: Tells PlatoSim if the inputCatalog has a column for Tstar (RA/DEC/Mag/T?/ID?). If yes, it will be read out. If not, all Stars are assumed G0V.
    - Use Spectral Dependency: If chosen, the flux will be split into wavelength bins according to the spectrum given by the stellar temperature. That way, correct transmission and quantum efficiency (If QE is turned on) are applied to each flux fraction. 
Other lines that were added modify the use of the spectral dependency.

The following files are changed:
    - Simulation.cpp/h: Added funtionality to read the spectral dependency switch. Based on this, Camera.cpp or CameraSpectral.cpp will be used. Also, the temperature of the stars is always passed to the output file, be it given by the catalog or chosen as G0V (5980K). 
    - Sky.cpp/h: Sky can now read if the inputfile contains stellar temperatures (switch mentioned before). If yes, correct temperatures are assigned to each star, otherwise G0V is chosen. The stellar temperature has been added to the starInfo tuple in all functions, to prevent creating a duplicate child class that would need to be altered witch all coming changes. An additional function has been added to fetch the temperature assigned to a star ID. This was done to prevent changes to the original Camera.cpp by adding it to the normal getSelectedStar.

New Files are as follows:
    - CameraSpectral.cpp/h: Child of Camera, adding parameters needed for the spectral dependency and changing the exposeDetector function (Only in the middle, but is a large function). Only used with spectral dependency. If QE is applied, spectral QE is already applied in this file, to avoid a larger loop in Detector.cpp. The average QE application later is kept, and countered by dividing by the meanQE in CameraSpectral.cpp
    - SpectralDependenceUtility.cpp/h: Reads all the new parameters needed for the spectral dependency. Includes error messages if bad parameters are chosen, and a warning if spectral dependency without temperature information is used (all stars then G0V). Also contains the calculation of spectrally degrading transmission, to avoid changes to telescope.cpp.