### PR TITLE
HDF5 → FITS: Organising serial pre-scan & parallel over-scan per window

### DIFF
--- a/python/hdf5ToFits.py
+++ b/python/hdf5ToFits.py
@@ -65,11 +65,11 @@ def hdf5ToFits(inputFilename, outputFilename):
             biasHeader["DATE-OBS"] = formattedTimestamp
 
             biasMapLeft = simFile.getBiasMapLeft(exposure)
-            biasHeader["EXTNAME"] = "SPRESCANE"
+            biasHeader["EXTNAME"] = "SPRESCANE1"
             fits.append(outputFilePath, biasMapLeft, biasHeader)
             
             biasMapRight = simFile.getBiasMapRight(exposure)
-            biasHeader["EXTNAME"] = "SPRESCANF"
+            biasHeader["EXTNAME"] = "SPRESCANF1"
             fits.append(outputFilePath, biasMapRight, biasHeader)
 
         # Parallel over-scan (smearing map)
@@ -289,7 +289,7 @@ def getParallelOverScanHeader(simFile: SimFile):
 
     # Using this keyword, the parallel over-scan will end up in the correct extension
 
-    header["EXTNAME"] = "POVERSCAN"
+    header["EXTNAME"] = "POVERSCAN1"
 
     return header
 


### PR DESCRIPTION
The window number is appended to the extension name (`EXTNAME`) of the serial pre-scan and parallel over-scan.