### PR TITLE
Big fix in orientation angle of PSF.

### DIFF
--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -566,9 +566,8 @@ bool DetectorWithAnalyticNonGaussianPSF::addFluxToMap(arma::Mat<float>& map, dou
 
     IntegralOfAnalyticSignalResponse psf(size, diffusionKernelWidth);
 
-    // FIXME
-    // double ccdOrientation = getOrientationAngle();
-    // p -= ccdOrientation;
+    double ccdOrientation = rotationAnglePsf;
+    p -= ccdOrientation;
 
     integrateAnalyticPSF(psf, column0, row0, r, p);
 


### PR DESCRIPTION
Implemented as suggested by Carsten.

Solves GitHub issue #511: Analytical Non Gaussian PSF: strange orientation of the PSF on the CCD.