### PR TITLE
Decrease in flux due to reflections off the CCD.

### DIFF
--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -713,6 +713,12 @@ void Camera::exposeDetectorWithStars(Detector &detector, double startTime, doubl
 
             fluxStar = floor(fluxFactor * pow(10.0, -0.4 * magStar) * timeStep);
 
+            // Account for the flux loss when ghosts are produced by the star
+
+            if(includeGhosts)
+            
+                fluxStar *= (1 - fluxRatioExtendedGhosts - fluxRatioPointLikeGhosts);
+
             // Try to add the flux at the appropriate pixel in the sub-field
             // Returned:
             //      - whether or not the source falls in the sub-field


### PR DESCRIPTION
The flux of a star received at the detector decreases by 0.08% + 0.00003%, due to reflections off the CCD surface.  Note that this is also the case for stars beyond 8° from the OA.  In despite of the fact that these stars do not produce point-like ghosts, there is in fact a reflection off the CCD surface, but the reflected rays will not make it through the pupil around L3 (and will therefore not reach the entrance window, where they would be reflected back towards the CCD, producing point-like ghosts).