### PR TITLE
Corrected calculation of the size of the extended ghosts

### DIFF
--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -800,7 +800,7 @@ void Camera::exposeDetectorWithStars(Detector &detector, double startTime, doubl
 
                 // The radius of the extended ghost is described by a 2nd-degree polynomial
 
-                distanceOA = this->getGnomonicRadialDistanceFromOpticalAxis(xGhost, yGhost);    // [radians]
+                distanceOA = rad2deg(this->getGnomonicRadialDistanceFromOpticalAxis(xGhost, yGhost));    // [degrees]
                 radiusExtendedGhost = coefficients[0] * pow(distanceOA, 2) + coefficients[1] * distanceOA + coefficients[2];    // [mm]
 
                 // Try to add the flux at the appropriate pixels in the sub-field


### PR DESCRIPTION
The radius of the extended ghosts is calculated from a polynomial in θ, where θ should be expressed in degrees, not in radians.