### PR TITLE
Fixed use of dialect `uint` in the closed loop modules of PlatoSim.

### DIFF
--- a/include/ClosedLoopUtility.h
+++ b/include/ClosedLoopUtility.h
@@ -10,7 +10,7 @@
 #include "Logger.h"
 
 
-
+typedef unsigned int uint;
 
 
 // this class governs the sending and receiving of messages between the used 

--- a/tests/closedLoopTest/connectionTest.cpp
+++ b/tests/closedLoopTest/connectionTest.cpp
@@ -9,6 +9,9 @@
 #include <thread>
 #include <unistd.h>
 
+
+typedef unsigned int uint;
+
 bool endTest = false;
 bool simsStarted = false;
 bool simsRunning = false;


### PR DESCRIPTION
Inserted an explicit `typedef unsigned int uint` statement in CloseLoopUtility.h and in connectionTest.cpp.