### PR TITLE
Explicitly check PSF sub-pixel resolution

### DIFF
--- a/include/PointSpreadFunction.h
+++ b/include/PointSpreadFunction.h
@@ -29,6 +29,7 @@ class PointSpreadFunction : public HDF5Writer
 
         virtual void rotate(double angle){};
 
+        int getNumSubPixelsPerPixel(){return numberOfSubPixelsPerPixel;};
         arma::fmat rebinToSubPixels(unsigned int targetSubPixels);
 
     protected:

--- a/source/DetectorWithAsymmetricalMappedPSF.cpp
+++ b/source/DetectorWithAsymmetricalMappedPSF.cpp
@@ -159,6 +159,13 @@ void DetectorWithAsymmetricalMappedPSF::setPsfForSubfield()
 
     psf->select(xFPmm, yFPmm);
 
+    if(psf->getNumSubPixelsPerPixel() < numSubPixelsPerPixel)
+    {
+        throw IllegalArgumentException(string("DetectorWithAsymmetricalMappedPSF.setPsfForSubfield: ") + 
+            "The sub-pixel resolution of the PSF (" + to_string(psf->getNumSubPixelsPerPixel()) +
+                    ") must be at least that of the sub-field (" + to_string(numSubPixelsPerPixel) + ")");
+    }
+
     //  Compensate for the orientation of the CCD wrt focal plane orientation.
 
     psf->rotate(-rotationAnglePsf);

--- a/source/DetectorWithSymmetricalMappedPSF.cpp
+++ b/source/DetectorWithSymmetricalMappedPSF.cpp
@@ -169,6 +169,13 @@ void DetectorWithSymmetricalMappedPSF::setPsfForSubfield()
 
     psf->select(radius);
 
+    if(psf->getNumSubPixelsPerPixel() < numSubPixelsPerPixel)
+    {
+        throw IllegalArgumentException(string("DetectorWithSymmetricalMappedPSF.setPsfForSubfield: ") + 
+            "The sub-pixel resolution of the PSF (" + to_string(psf->getNumSubPixelsPerPixel()) +
+                    ") must be at least that of the sub-field (" + to_string(numSubPixelsPerPixel) + ")");
+    }
+
     // Get the 'user specified' orientation angle from the psf.
     // if the user didn't specify a rotation angle, calculate it
     // from the given focal plane coordinates.


### PR DESCRIPTION
Explicitly check whether the sub-pixel resolution of the (mapped) PSF is at least that of the sub-field.  If not, an exception with a proper message is thrown.

See #530.