### PR TITLE
Corrected flux ratio for extended ghosts.

### DIFF
--- a/docs/tutorials/FineGuidanceStars/inputfgs.yaml
+++ b/docs/tutorials/FineGuidanceStars/inputfgs.yaml
@@ -96,7 +96,7 @@ Camera:
             FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]
             DistanceCutOff:          8                          # Sources within this radius from the optical axis produce a point-like ghost [degrees]
         Extended:
-            FluxRatio:               0.00003                    # Flux ratio between the extended ghost and the originating source [%]
+            FluxRatio:               0.06                       # Flux ratio between the extended ghost and the originating source [%]
             RadiusCoefficients:      [0.0062, -0.0251, 1.8402]  # Coefficients of the 2nd-degree polynomial (in distance from the optical axis), describing the radius of the (circular) extended source
             DistanceRatio:           1.065                      # For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)
 

--- a/docs/tutorials/Photometry/inputphot.yaml
+++ b/docs/tutorials/Photometry/inputphot.yaml
@@ -94,7 +94,7 @@ Camera:
             FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]
             DistanceCutOff:          8                          # Sources within this radius from the optical axis produce a point-like ghost [degrees]
         Extended:
-            FluxRatio:               0.00003                    # Flux ratio between the extended ghost and the originating source [%]
+            FluxRatio:               0.06                       # Flux ratio between the extended ghost and the originating source [%]
             RadiusCoefficients:      [0.0062, -0.0251, 1.8402]  # Coefficients of the 2nd-degree polynomial (in distance from the optical axis), describing the radius of the (circular) extended source
             DistanceRatio:           1.065                      # For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)
 

--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -93,7 +93,7 @@ Camera:
             FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]
             DistanceCutOff:          8                          # Sources within this radius from the optical axis produce a point-like ghost [degrees]
         Extended:
-            FluxRatio:               0.00003                    # Flux ratio between the extended ghost and the originating source [%]
+            FluxRatio:               0.06                       # Flux ratio between the extended ghost and the originating source [%]
             RadiusCoefficients:      [0.0062, -0.0251, 1.8402]  # Coefficients of the 2nd-degree polynomial (in distance from the optical axis), describing the radius of the (circular) extended source
             DistanceRatio:           1.065                      # For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)
 

--- a/python/Examples/closedLoopTest/offlineInput.yaml
+++ b/python/Examples/closedLoopTest/offlineInput.yaml
@@ -96,7 +96,7 @@ Camera:
             FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]
             DistanceCutOff:          8                          # Sources within this radius from the optical axis produce a point-like ghost [degrees]
         Extended:
-            FluxRatio:               0.00003                    # Flux ratio between the extended ghost and the originating source [%]
+            FluxRatio:               0.06                       # Flux ratio between the extended ghost and the originating source [%]
             RadiusCoefficients:      [0.0062, -0.0251, 1.8402]  # Coefficients of the 2nd-degree polynomial (in distance from the optical axis), describing the radius of the (circular) extended source
             DistanceRatio:           1.065                      # For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)
 

--- a/python/Examples/closedLoopTest/onlineInput.yaml
+++ b/python/Examples/closedLoopTest/onlineInput.yaml
@@ -96,7 +96,7 @@ Camera:
             FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]
             DistanceCutOff:          8                          # Sources within this radius from the optical axis produce a point-like ghost [degrees]
         Extended:
-            FluxRatio:               0.00003                    # Flux ratio between the extended ghost and the originating source [%]
+            FluxRatio:               0.06                       # Flux ratio between the extended ghost and the originating source [%]
             RadiusCoefficients:      [0.0062, -0.0251, 1.8402]  # Coefficients of the 2nd-degree polynomial (in distance from the optical axis), describing the radius of the (circular) extended source
             DistanceRatio:           1.065                      # For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)
 

--- a/testData/input_CameraTest.yaml
+++ b/testData/input_CameraTest.yaml
@@ -83,7 +83,15 @@ Camera:
         ConstantCoefficients:        [0.316257210577,  0.066373219688,  0.372589221219] # In case Source is ConstantValue
         ConstantInverseCoefficients: [-0.317143032936, 0.242638513347, -0.459260203502] # In case Source is ConstantValue
         CoefficientsFromFile:        inputfiles/distortioncoefficients.txt                                    # In case Source is FromFile
-        InverseCoefficientsFromFile: inputfiles/distortioninversecoefficients.txt                             # In case Source if FromFile
+    IncludeGhosts:                   yes
+    Ghosts:
+        PointLike:
+            FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]
+            DistanceCutOff:          8                          # Sources within this radius from the optical axis produce a point-like ghost [degrees]
+        Extended:
+            FluxRatio:               0.06                       # Flux ratio between the extended ghost and the originating source [%]
+            RadiusCoefficients:      [0.0062, -0.0251, 1.8402]  # Coefficients of the 2nd-degree polynomial (in distance from the optical axis), describing the radius of the (circular) extended source
+            DistanceRatio:           1.065                      # For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)
 
 PSF:
 

--- a/testData/input_DetectorTest.yaml
+++ b/testData/input_DetectorTest.yaml
@@ -88,6 +88,14 @@ Camera:
         ConstantInverseCoefficients: [-0.317143032936, 0.242638513347,-0.459260203502]  # In case Source is ConstantValue
         CoefficientsFromFile:        inputfiles/distortioncoefficients.txt                                    # In case Source is FromFile
         InverseCoefficientsFromFile: inputfiles/distortioninversecoefficients.txt                             # In case Source if FromFile
+    Ghosts:
+        PointLike:
+            FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]
+            DistanceCutOff:          8                          # Sources within this radius from the optical axis produce a point-like ghost [degrees]
+        Extended:
+            FluxRatio:               0.06                       # Flux ratio between the extended ghost and the originating source [%]
+            RadiusCoefficients:      [0.0062, -0.0251, 1.8402]  # Coefficients of the 2nd-degree polynomial (in distance from the optical axis), describing the radius of the (circular) extended source
+            DistanceRatio:           1.065                      # For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)
 
 PSF:
 

--- a/testData/input_StarCatalogTest.yaml
+++ b/testData/input_StarCatalogTest.yaml
@@ -86,6 +86,14 @@ Camera:
         ConstantInverseCoefficients: [-0.317143032936, 0.242638513347, -0.459260203502] # In case Source is ConstantValue
         CoefficientsFromFile:        inputfiles/distortioncoefficients.txt                                    # In case Source is FromFile
         InverseCoefficientsFromFile: inputfiles/distortioninversecoefficients.txt                             # In case Source if FromFile
+    Ghosts:
+        PointLike:
+            FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]
+            DistanceCutOff:          8                          # Sources within this radius from the optical axis produce a point-like ghost [degrees]
+        Extended:
+            FluxRatio:               0.06                       # Flux ratio between the extended ghost and the originating source [%]
+            RadiusCoefficients:      [0.0062, -0.0251, 1.8402]  # Coefficients of the 2nd-degree polynomial (in distance from the optical axis), describing the radius of the (circular) extended source
+            DistanceRatio:           1.065                      # For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)
 
 
 PSF:


### PR DESCRIPTION
- Old value: 0.00003% # → only valid for the irradiance ratio;
- New value: 0.06% → valid for the flux ratio.