### PR TITLE
Fixed issue #555 where the Brighter-Fatter effect doesn't affect the …

### DIFF
--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -936,13 +936,14 @@ bool Detector::isInPixelMap(double row, double column)
 
 
 
-/**
+/*
  * \brief Apply throughput efficiency. This is the combined effect of:
  *          - vignetting (brightness attenuation towards the edges of the FOV);
  *          - particulate contamination;
  *          - molecular contamination;
  *          - quantum efficiency.
  */
+
 
 void Detector::applyThroughputEfficiency()
 {
@@ -1058,11 +1059,12 @@ void Detector::addDarkSignal(float exposureTime)
 
 /**
  * \brief: Reads out the detector and apply the following effects:
- *          - photon noise
- *          - full-well saturation (i.e. blooming)
+ *          - Cosmics
+ *          - BFE
  *          - CTE
- *          - open-shutter smearing
+ *          - full-well saturation (i.e. blooming)
  *          - readout noise
+ *          - F-FEE over-/under shoot
  *          - quantisation:
  *              - gain
  *              - electronic offset (i.e. bias)
@@ -1093,20 +1095,18 @@ void Detector::readOut(float exposureTime)
         Log.debug("Detector: no cosmic hits included.");
     }
 
-    // Apply the effects of readout smearing due to an open shutter. Because there is no shutter,
-    // the pixels are still receiving photons from the sky, while they are being transfered towards
-    // the readout register.
-    // Pixel units before: [electrons]
-    // Pixel units after: [electrons]
 
-    if (includeOpenShutterSmearing)
+    // Brighter-Fatter effect
+
+    if (includeBFE)
     {
-        Log.debug("Detector: applying open shutter smearing.");
-        applyOpenShutterSmearing(exposureTime);
+        Log.debug("DetectorWithMappedPSF: adding Brighter-Fatter effect");
+
+        applyBFE();
     }
     else
     {
-        Log.debug("Detector: no open shutter smearing applied.");
+        Log.debug("DetectorWithMappedPSF: no Brighter-Fatter effect added");
     }
 
     // Simulate the effects of the Charge Transfer Inefficiency (CTI). When the
@@ -1126,48 +1126,6 @@ void Detector::readOut(float exposureTime)
         Log.debug("Detector: no charge transfer inefficiency applied.");
     }
 
-    // Apply poisson distributed photon noise
-    // Pixel units before: [electrons]
-    // Pixel units after: [electrons]
-
-    if (includePhotonNoise)
-    {
-        Log.debug("Detector: adding photon noise.");
-        addPhotonNoise();
-    }
-    else
-    {
-        Log.debug("Detector: no photon noise added.");
-    }
-
-    // Apply the F-FEE over-/undershoot to the pixel map.
-    // Pixel units before of pixel, smearing and bias maps: [ADU]
-    // Pixel units after of  pixel, smearing and bias maps: [ADU]
-
-    if(isFastCamera && frontEndElectronics->getIncludeOverAndUnderShoot())
-    {
-        Log.debug("Detector: adding (F-)FEE over-/undershoot");
-        applyOverAndUnderShoot();
-    }
-    else{
-        Log.debug("Detector: (F-)FEE over-/undershoot not applied: " + to_string(isFastCamera) + " " + to_string(frontEndElectronics->getIncludeOverAndUnderShoot()));
-    }
-
-    // Each time the amplifier reads out a pixel, a tiny bit of noise is added.
-    // Add the readout noise.
-    // Pixel units before: [electrons]
-    // Pixel units after: [electrons]
-
-    if (includeReadoutNoise)
-    {
-        Log.debug("Detector: adding readout noise of CCD and FEE.");
-        addReadoutNoise();
-    }
-    else
-    {
-        Log.debug("Detector: no readout noise added.");
-    }
-
     // Apply full-well saturation. A pixel has a maximum capacity of electrons (the full well capacity).
     // If photons free more electrons, the pixel saturates, and the electrons flow in the pixels above and below in
     // the same column (potential barriers are smallest in that direction).
@@ -1184,13 +1142,42 @@ void Detector::readOut(float exposureTime)
         Log.debug("Detector: no full well saturation applied.");
     }
 
+
+    // Each time the amplifier reads out a pixel, a tiny bit of noise is added.
+    // Add the readout noise.
+    // Pixel units before: [electrons]
+    // Pixel units after: [electrons]
+
+    if (includeReadoutNoise)
+    {
+        Log.debug("Detector: adding readout noise of CCD and FEE.");
+        addReadoutNoise();
+    }
+    else
+    {
+        Log.debug("Detector: no readout noise added.");
+    }
+    
+    // Apply the F-FEE over-/undershoot to the pixel map.
+    // Pixel units before of pixel, smearing and bias maps: [ADU]
+    // Pixel units after of  pixel, smearing and bias maps: [ADU]
+
+    if(isFastCamera && frontEndElectronics->getIncludeOverAndUnderShoot())
+    {
+        Log.debug("Detector: adding (F-)FEE over-/undershoot");
+        applyOverAndUnderShoot();
+    }
+    else{
+        Log.debug("Detector: (F-)FEE over-/undershoot not applied: " + to_string(isFastCamera) + " " + to_string(frontEndElectronics->getIncludeOverAndUnderShoot()));
+    }
+
+
     //  Apply quantisation. This consists of:
     //         - applying FEE and CCD gain (converting from electrons to ADU)
     //         - adding the electronic offset
     //         - applying digital saturation
     // Pixel units before: [electrons]
     // Pixel units after: [ADU]
-
 
     if(includeQuantisation)
     {

--- a/source/DetectorWithAnalyticGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticGaussianPSF.cpp
@@ -286,13 +286,13 @@ void DetectorWithAnalyticGaussianPSF::integrateLight(int exposureNr, double star
     // Apply throughput efficiency on the pixel map.
     // This takes into account the QE, vignetting, polarisation, and particulate & molecular contamination.
     // PixelMap units change from [photons] to [electrons] 
-    
+
     applyThroughputEfficiency();
 
     // Apply the charge injection which will mitigate the CTI. The injection happens in electrons, 
     // so the throughput efficiency should already have been applied. The injected charges do feel the PRNU, 
     // so applying the flatfied should happen afterwards.
-    
+
     if (includeChargeInjection)
     {
         Log.debug("Detector: applying charge injection");
@@ -314,6 +314,39 @@ void DetectorWithAnalyticGaussianPSF::integrateLight(int exposureNr, double star
     }
 
 
+
+    // Apply the effects of readout smearing due to an open shutter. Because there is no shutter,
+    // the pixels are still receiving photons from the sky, while they are being transfered towards
+    // the readout register.
+    // Pixel units before: [electrons]
+    // Pixel units after: [electrons]
+
+    if (includeOpenShutterSmearing)
+    {
+        Log.debug("Detector: applying open shutter smearing.");
+        applyOpenShutterSmearing(exposureTime);
+    }
+    else
+    {
+         Log.debug("Detector: no open shutter smearing applied.");
+    }
+
+    // Apply poisson distributed photon noise
+    // Pixel units before: [electrons]
+    // Pixel units after: [electrons]
+
+    if (includePhotonNoise)
+    {
+        Log.debug("Detector: adding photon noise.");
+        addPhotonNoise();
+    }
+    else
+    {
+        Log.debug("Detector: no photon noise added.");
+    }
+
+
+    
     // Add dark current
 
     if(includeDarkSignal)
@@ -327,18 +360,8 @@ void DetectorWithAnalyticGaussianPSF::integrateLight(int exposureNr, double star
         Log.debug("Detector: no dark current added");
     }
 
-    // Brighter-fatter effect
 
-    if(includeBFE)
-    {
-   		Log.debug("Detector: adding Brighter-Fatter effect");
-
-   		applyBFE();
-    }
-    else
-    {
-        Log.debug("Detector: no Brighter-Fatter effect added");
-    }
+    
 }
 
 

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -471,20 +471,20 @@ void DetectorWithAnalyticNonGaussianPSF::integrateLight(int exposureNr, double s
 {
 
     // Integration (incl. jitter): point sources + background
-
+ 
     camera.exposeDetectorWithStars(*this, startTime, exposureTime, readoutTimeBeforeNextExposure);
     camera.exposeDetectorWithSkyBackground(*this, startTime, exposureTime, readoutTimeBeforeNextExposure);
 
     // Apply throughput efficiency on the pixel map.
     // This takes into account the QE, vignetting, polarisation, and particulate & molecular contamination.
     // PixelMap units change from [photons] to [electrons] 
-    
+ 
     applyThroughputEfficiency();
 
     // Apply the charge injection which will mitigate the CTI. The injection happens in electrons, 
     // so the throughput efficiency should already have been applied. The injected charges do feel the PRNU, 
     // so applying the flatfied should happen afterwards.
-    
+ 
     if (includeChargeInjection)
     {
         Log.debug("Detector: applying charge injection");
@@ -492,7 +492,7 @@ void DetectorWithAnalyticNonGaussianPSF::integrateLight(int exposureNr, double s
     }
 
     // Apply flatfield (at pixel level)
-
+ 
     if (includeFlatfield)
     {
         Log.debug("Detector: applying Flatfield.");
@@ -504,6 +504,36 @@ void DetectorWithAnalyticNonGaussianPSF::integrateLight(int exposureNr, double s
         Log.debug("Detector: no flatfield applied.");
     }
 
+    // Apply the effects of readout smearing due to an open shutter. Because there is no shutter,
+    // the pixels are still receiving photons from the sky, while they are being transfered towards
+    // the readout register.
+    // Pixel units before: [electrons]
+    // Pixel units after: [electrons]
+
+    if (includeOpenShutterSmearing)
+    {
+        Log.debug("Detector: applying open shutter smearing.");
+        applyOpenShutterSmearing(exposureTime);
+    }
+    else
+    {
+         Log.debug("Detector: no open shutter smearing applied.");
+    }
+
+    // Apply poisson distributed photon noise
+    // Pixel units before: [electrons]
+    // Pixel units after: [electrons]
+    
+    if (includePhotonNoise)
+    {
+        Log.debug("Detector: adding photon noise.");
+        addPhotonNoise();
+    }
+    else
+    {
+        Log.debug("Detector: no photon noise added.");
+    }
+    
     // Add dark current
 
     if(includeDarkSignal)
@@ -517,18 +547,7 @@ void DetectorWithAnalyticNonGaussianPSF::integrateLight(int exposureNr, double s
     		Log.debug("Detector: no dark current added");
     }
 
-    // Brighter-Fatter effect
 
-    if(includeBFE)
-    {
-    		Log.debug("Detector: adding Brighter-Fatter effect");
-
-       	applyBFE();
-    }
-    else
-    {
-        Log.debug("Detector: no Brighter-Fatter effect added");
-    }
 }
 
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -310,12 +310,47 @@ void DetectorWithMappedPSF::integrateLight(int exposureNr, double startTime, dou
     // feel the PRNU, but for the MappedPSF we first need to apply the PRNU on sub-pixel level and afterwards
     // apply the throughputEfficiency() at pixel level, so there is no possibilty to respect the order
     // (1) throughput (2) charge injection (3) PRNU.
-    
+
     if (includeChargeInjection)
     {
         Log.debug("Detector: applying charge injection");
         applyChargeInjection();
     }
+
+
+
+    // Apply the effects of readout smearing due to an open shutter. Because there is no shutter,
+    // the pixels are still receiving photons from the sky, while they are being transfered towards
+    // the readout register.
+    // Pixel units before: [electrons]
+    // Pixel units after: [electrons]
+
+
+    if (includeOpenShutterSmearing)
+    {
+        Log.debug("Detector: applying open shutter smearing.");
+        applyOpenShutterSmearing(exposureTime);
+    }
+    else
+    {
+         Log.debug("Detector: no open shutter smearing applied.");
+    }
+
+    // Apply poisson distributed photon noise
+    // Pixel units before: [electrons]
+    // Pixel units after: [electrons]
+    
+
+    if (includePhotonNoise)
+    {
+        Log.debug("Detector: adding photon noise.");
+        addPhotonNoise();
+    }
+    else
+    {
+        Log.debug("Detector: no photon noise added.");
+    }
+
 
     // Add dark current
 
@@ -330,18 +365,6 @@ void DetectorWithMappedPSF::integrateLight(int exposureNr, double startTime, dou
         Log.debug("Detector: no dark current added");
     }
 
-    // Brighter-Fatter effect
-
-    if (includeBFE)
-    {
-        Log.debug("DetectorWithMappedPSF: adding Brighter-Fatter effect");
-
-        applyBFE();
-    }
-    else
-    {
-        Log.debug("DetectorWithMappedPSF: no Brighter-Fatter effect added");
-    }
 }
 
 


### PR DESCRIPTION
…photon transfer curve. The order in which the effects are applied has been changed. The current order is:

For detectors with mapped PSF:
1. Expose with stars
2. Expose with background
3. Include flatfield
4. Apply throughput Efficiency
5. Charge Injection
6. Open Shutter Smearing
7. Photon Noise
8. Dark current
9. Cosmics
10. BFE
11. CTI
12. Full well saturation
13. F-FEE over-/under shoot
14. Quantisation

For the detectors with analytic PSF, the flatfield is applied after charge injection.