### PR TITLE
Apply the BFE after full well saturation

### DIFF
--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -1095,20 +1095,6 @@ void Detector::readOut(float exposureTime)
         Log.debug("Detector: no cosmic hits included.");
     }
 
-
-    // Brighter-Fatter effect
-
-    if (includeBFE)
-    {
-        Log.debug("DetectorWithMappedPSF: adding Brighter-Fatter effect");
-
-        applyBFE();
-    }
-    else
-    {
-        Log.debug("DetectorWithMappedPSF: no Brighter-Fatter effect added");
-    }
-
     // Simulate the effects of the Charge Transfer Inefficiency (CTI). When the
     // CCD is read out, row after row, a part of the charge is always left behind
     // which then dribbles into the trailing pixels. This causes each star to have
@@ -1142,6 +1128,20 @@ void Detector::readOut(float exposureTime)
         Log.debug("Detector: no full well saturation applied.");
     }
 
+
+
+    // Brighter-Fatter effect
+
+    if (includeBFE)
+    {
+        Log.debug("DetectorWithMappedPSF: adding Brighter-Fatter effect");
+
+        applyBFE();
+    }
+    else
+    {
+        Log.debug("DetectorWithMappedPSF: no Brighter-Fatter effect added");
+    }
 
     // Each time the amplifier reads out a pixel, a tiny bit of noise is added.
     // Add the readout noise.
@@ -1211,6 +1211,7 @@ void Detector::readOut(float exposureTime)
  */
 void Detector::applyBFE()
 {
+
     // For each pixel (0, 0), we only account for the influence of pixels (i, j)
     // that are within the given range (to evaluate Eq. (11) in Guyonnet et al.)
 


### PR DESCRIPTION
Fixes issue #584. The current implementation of the BFE for PlatoSim
is not accurate for large pixels (as is the case for the Plato
mission). Because of this approximation, this implementation allows for more
charge to be distracted from a pixel than is available for very bright
pixels. This commit fixes this by first applying blooming so that
there won't be any pixels with too large values.