### PR TITLE
Keep diffused PSF in the output file

### DIFF
--- a/include/DetectorWithMappedPSF.h
+++ b/include/DetectorWithMappedPSF.h
@@ -29,6 +29,8 @@ class DetectorWithMappedPSF : public Detector
         virtual tuple<bool, double, double> addExtendedGhost(double xFP, double yFP, double radius, double flux) override;
 
         virtual void configure(ConfigurationParameters &configParam){};
+        void writeDiffusedPSFToHDF5(PointSpreadFunction *psf);
+        void applyDiffusionKernelOnPSF(double subpixRow, double subpixColumn, double flux, arma::fmat& psf, int numberOfPsfSubpixelsPerPixel);
 
     protected:
 
@@ -65,6 +67,8 @@ class DetectorWithMappedPSF : public Detector
         bool writeFlatfieldMap;                 // Whether or not to write the flatfield map to the HDF5 file
         bool writeSubPixelImagesToHDF5;         // Write subpixel maps to HDF5 as well
         bool includeConvolution;                // Whether or not to convolve the subPixelMap with the PSF
+
+        bool writeDiffusedPSF;                  // Whether or not to write the diffused PSF to the output HDF5 file
 
         arma::Mat<float> diffusionKernel;                    // Diffusion kernel image
         IntegralOfAnalyticSignalResponse signalResponse;	 // Signal response

--- a/include/PointSpreadFunction.h
+++ b/include/PointSpreadFunction.h
@@ -31,6 +31,7 @@ class PointSpreadFunction : public HDF5Writer
 
         int getNumSubPixelsPerPixel(){return numberOfSubPixelsPerPixel;};
         arma::fmat rebinToSubPixels(unsigned int targetSubPixels);
+        arma::fmat getOriginalPSF();
 
     protected:
 

--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -286,7 +286,7 @@ ControlHDF5Content:
     WriteGhostPositions:             yes             # Ghost positions are written in pixel and focal plane coordinates
     WriteACS:                        yes             # Whether to write the yaw, pitch, roll to the HDF5 file
     WriteCosmics:                    yes             # Determines if the columns, rows and flux of the cosmics should be written to the HDF5 file 
-
+    WriteDiffusedPSF:                no              # Determines if diffused PSF should be written to the output HDF5 file. (Only works for mapped PSF, takes a long time to compute)
 
 
 ControlTcpConnection:

--- a/python/platosim/simfile.py
+++ b/python/platosim/simfile.py
@@ -472,7 +472,7 @@ class SimFile (object):
         """
         PURPOSE: extract the PSF from the HDF5 file (if present)
 
-        INPUT:   the PSF name: "rebinnedPSFpixel", "rebinnedPSFsubPixel", or "rotatedPSF"
+        INPUT:   the PSF name: "rebinnedPSFpixel", "rebinnedPSFsubPixel", "rotatedPSF" or "diffusedPSF"
                  where rotatedPSF is at subpixel level.
                  
         OUTPUT:  psf: 2D numpy array containing the image

--- a/source/DetectorWithAsymmetricalMappedPSF.cpp
+++ b/source/DetectorWithAsymmetricalMappedPSF.cpp
@@ -131,6 +131,7 @@ void DetectorWithAsymmetricalMappedPSF::configure(ConfigurationParameters &confi
     // The configuration for the HDF5 contents
 
     writeFlatfieldMap = configParam.getBoolean("ControlHDF5Content/WriteFlatfieldMap");
+    writeDiffusedPSF = configParam.getBoolean("ControlHDF5Content/WriteDiffusedPSF");
 }
 
 
@@ -166,6 +167,12 @@ void DetectorWithAsymmetricalMappedPSF::setPsfForSubfield()
                     ") must be at least that of the sub-field (" + to_string(numSubPixelsPerPixel) + ")");
     }
 
+    // If requestied save the diffused PSF to the output file
+    if (writeDiffusedPSF)
+    {
+      writeDiffusedPSFToHDF5(psf);
+    }
+    
     //  Compensate for the orientation of the CCD wrt focal plane orientation.
 
     psf->rotate(-rotationAnglePsf);
@@ -179,3 +186,7 @@ void DetectorWithAsymmetricalMappedPSF::setPsfForSubfield()
 
     convolver.initialise(numRowsSubPixelMap, numColumnsSubPixelMap, psfMap);
 }
+
+
+
+

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -746,3 +746,78 @@ void DetectorWithMappedPSF::writeSubPixelMapToHDF5(int exposureNr)
 
 
 
+
+
+/** 
+ * \brief: Write the diffused PSF to the HDF5 file.
+ */
+
+void DetectorWithMappedPSF::writeDiffusedPSFToHDF5(PointSpreadFunction *psf)
+{
+    arma::fmat psfMap = psf->getOriginalPSF();
+    arma::fmat diffusedPsf = arma::fmat(size(psfMap), arma::fill::zeros);
+
+    int numRows = size(psfMap)(0);
+    int numColumns = size(psfMap)(1);
+
+    // set the diffusion kernel image size
+    int psfSubPixelsPerPixel = psf->getNumSubPixelsPerPixel();
+    generateDiffusionKernel(chargeDiffusionStrength*psfSubPixelsPerPixel);
+    
+    
+    for (int row=0; row < numRows; row++)
+    {
+      for (int column=0; column < numColumns; column++)
+      {
+       	applyDiffusionKernelOnPSF(row, column, psfMap(row, column), diffusedPsf, psfSubPixelsPerPixel);
+	//	std::cout << "psfMap" << psfMap(row, column) << std::endl;
+      }
+    }
+
+    // reset the diffusion kernel
+    generateDiffusionKernel(chargeDiffusionStrength*numSubPixelsPerPixel);
+
+    // write the diffused psf to the output hdf5 file
+    hdf5File.writeArray("/PSF", "diffusedPSF", diffusedPsf);
+}
+
+
+
+
+
+
+
+void DetectorWithMappedPSF::applyDiffusionKernelOnPSF(double subpixRow, double subpixColumn, double flux, arma::fmat& psf, int numberOfPsfSubpixelsPerPixel)
+{
+    int sx = subpixColumn - (diffusionKernelImageSize - 1) / 2;
+    int sy = subpixRow - (diffusionKernelImageSize - 1) / 2;
+
+    double ox = subpixColumn - floor(subpixColumn);
+    double oy = subpixRow - floor(subpixRow);
+
+    int numRows = size(psf)(0);
+    int numColumns = size(psf)(1);
+
+    // Establish diffusion kernel image
+
+    signalResponse = IntegralOfAnalyticSignalResponse(diffusionKernelImageSize);
+    signalResponse.addPart(ox, oy, 1., diffusionKernelWidth);
+
+    for (unsigned int row = 0; row < diffusionKernelImageSize; row++)
+    {
+        for (unsigned int column = 0; column < diffusionKernelImageSize; column++)
+        {
+            diffusionKernel(row, column) = signalResponse(column, row); // Normalisation done by ()-operator
+        }
+    }
+
+    // Add the flux to the psf 
+
+    arma::span rowSpan = arma::span(max(0, sy), min((int)numRows, sy + diffusionKernelImageSize) - 1);
+    arma::span columnSpan = arma::span(max(0, sx), min((int)numColumns, sx + diffusionKernelImageSize) - 1);
+
+    arma::span xSpan = arma::span(max(0, sx) - sx, min((int)numColumns, sx + diffusionKernelImageSize) - sx - 1);
+    arma::span ySpan = arma::span(max(0, sy) - sy, min((int)numRows, sy + diffusionKernelImageSize) - sy - 1);
+
+    psf(rowSpan, columnSpan) += diffusionKernel(ySpan, xSpan) * flux;
+}

--- a/source/DetectorWithSymmetricalMappedPSF.cpp
+++ b/source/DetectorWithSymmetricalMappedPSF.cpp
@@ -131,6 +131,7 @@ void DetectorWithSymmetricalMappedPSF::configure(ConfigurationParameters &config
     // The configuration for the HDF5 contents
 
     writeFlatfieldMap = configParam.getBoolean("ControlHDF5Content/WriteFlatfieldMap");
+    writeDiffusedPSF = configParam.getBoolean("ControlHDF5Content/WriteDiffusedPSF");
 }
 
 
@@ -185,6 +186,12 @@ void DetectorWithSymmetricalMappedPSF::setPsfForSubfield()
     if (angle < 0.0)
     {
         angle = atan2(yFPmm, xFPmm);
+    }
+
+    // If requested save the diffused PSF to the output file
+    if (writeDiffusedPSF)
+    {
+        writeDiffusedPSFToHDF5(psf);
     }
 
     //  Compensate for the orientation of the CCD wrt focal plane orientation.

--- a/source/Platform.cpp
+++ b/source/Platform.cpp
@@ -203,8 +203,9 @@ void Platform::setPointingCoordinates(double rightAscencsion, double declination
 
 void Platform::updatePlatformOrientation(double time)
 {
-    double yaw=0.0, pitch=0.0, roll=0.0;
 
+    double yaw=0.0, pitch=0.0, roll=0.0;
+    //    Log.warning("Platform: We use the jitter " + to_string(useJitter));
     if (useJitter)
     {
         // Check if the request is going backwards in time. If so: complain.
@@ -233,7 +234,6 @@ void Platform::updatePlatformOrientation(double time)
 
         // We're now in the case that we haven't processed the given time point yet.
         // Let the platfrom jitter until 'time'. Yaw, pitch, and roll are in [rad]
-
         tie(yaw, pitch, roll) = jitterGenerator.getNextYawPitchRoll(time);
 
         Log.debug("Platform: At time " + to_string(time) + ": (yaw, pitch, roll) = (" 

--- a/source/PointSpreadFunction.cpp
+++ b/source/PointSpreadFunction.cpp
@@ -59,7 +59,7 @@ void PointSpreadFunction::initHDF5Groups()
 void PointSpreadFunction::flushOutput()
 {
     Log.info("PointSpreadFunction: Flushing output to HDf5 file.");
-
+    
     if (!isSelected)
         return;
     
@@ -131,3 +131,23 @@ arma::fmat PointSpreadFunction::rebinToSubPixels(unsigned int targetSubPixels)
 
     return rebinnedMap;
 }
+
+
+
+
+
+
+
+/*
+ * This function gets the selected psf
+ */
+
+arma::fmat PointSpreadFunction::getOriginalPSF()
+{
+  psfMap = ArrayOperations::rotateArray(psfMap, -rotationAngle);
+  psfMap /= arma::accu(psfMap);
+  return psfMap;
+}
+
+
+

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -560,9 +560,8 @@ void Simulation::writeStarCatalogToHDF5()
 
     // For all detected stars, copy the equatorial sky coordinates and the magnitude 
     // from the user-given star catalog to the output HDF5 file in a custom group.
-    
-    hdf5File->createGroup("/StarCatalog");
 
+    hdf5File->createGroup("/StarCatalog");
     const int Nstars = allStarIDs.size();
     vector<unsigned int> starIDs(Nstars);    // set<> is not contiguous, vector<> is. Needed for HDF5.
     vector<double> RA(Nstars);


### PR DESCRIPTION
Implemented feature request #564. It is now possible to record the diffused PSF in the output file by switching on the parameter in the input file: "WriteDiffusedPSF". Remark that this calculation can take a long time, so this shouldn't happen by default. 