### PR TITLE
Time shift is not applied for fast cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog for PlatoSim
 
+<!-- 3.4.2 -->
+<!-- ***** -->
+
+## **/**/2021: 3.4.2
+
+## Fixed
+* Time shift is not applied when reading out CCDs for the F-CAMs (GitHub #540)
+
+## Changed
+
+## Added
+
+
+
+
 <!-- 3.4.1 -->
 <!-- ***** -->
 
@@ -26,6 +41,7 @@
     - Star Catalog
     - Platoform Yaw, Pitch, Roll
     - Transmission Efficiency
+			     
 
 
 

--- a/source/JitterFromFile.cpp
+++ b/source/JitterFromFile.cpp
@@ -174,22 +174,27 @@ void JitterFromFile::configure(ConfigurationParameters &configParams)
     int beginExposureNr = configParams.getInteger("ObservingParameters/BeginExposureNr");
     double cycleTime    = configParams.getDouble("ObservingParameters/CycleTime");
     string ccdPosition  = configParams.getString("CCD/Position");
+    bool isFastCamera   = configParams.getString("Telescope/GroupID") == "Fast";    
 
     double timeShift;
     if (ccdPosition == "Custom")
     {
         timeShift = configParams.getDouble("CCD/TimeShift");
     }
-    else
+    else if (!isFastCamera)
     {
         int index = stoi(ccdPosition) - 1;   // Position are named  [1, 2, 3, 4] while the index into vector starts at 0
         timeShift = configParams.getDoubleAt("CCDPositions/TimeShift", index);
+    }
+    else
+    {
+        timeShift = 0.0;
     }
 
     //  Determine from when to when the simulation runs. Only for this time interval
     //  we need to read the jitter file into memory. This saves time when the jitter
     //  file is large but the simulation is short.
-    
+
     beginTime = timeShift + beginExposureNr * cycleTime;
     endTime   = beginTime + numExposures * cycleTime;
 }

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -262,14 +262,19 @@ void Simulation::configure(ConfigurationParameters &configParams)
     // Find out the right time shift.
 
     string ccdPosition              = configParams.getString("CCD/Position");
+    bool isFastCamera               = configParams.getString("Telescope/GroupID") == "Fast";
     if (ccdPosition == "Custom")
     {
         timeShift = configParams.getDouble("CCD/TimeShift");
     }
-    else
+    else if (!isFastCamera)
     {
         int index = stoi(ccdPosition) - 1;   // Position are named  [1, 2, 3, 4] while the index into vector starts at 0
         timeShift = configParams.getDoubleAt("CCDPositions/TimeShift", index);
+    }
+    else
+    {
+        timeShift = 0.0;
     }
 
     Log.debug("Simulation: configure(): time shift for current CCD configuration: " + to_string(timeShift));

--- a/source/ThermoElasticDriftFromFile.cpp
+++ b/source/ThermoElasticDriftFromFile.cpp
@@ -163,22 +163,27 @@ void ThermoElasticDriftFromFile::configure(ConfigurationParameters &configParams
     int beginExposureNr = configParams.getInteger("ObservingParameters/BeginExposureNr");
     double cycleTime    = configParams.getDouble("ObservingParameters/CycleTime");
     string ccdPosition  = configParams.getString("CCD/Position");
-
+    bool isFastCamera   = configParams.getString("Telescope/GroupID") == "Fast";
+    
     double timeShift;
     if (ccdPosition == "Custom")
     {
         timeShift = configParams.getDouble("CCD/TimeShift");
     }
-    else
+    else if (!isFastCamera)
     {
         int index = stoi(ccdPosition) - 1;   // Position are named  [1, 2, 3, 4] while the index into vector starts at 0
         timeShift = configParams.getDoubleAt("CCDPositions/TimeShift", index);
+    }
+    else
+    {
+        timeShift = 0.0;
     }
 
     //  Determine from when to when the simulation runs. Only for this time interval
     //  we need to read the jitter file into memory. This saves time when the jitter
     //  file is large but the simulation is short.
-    
+
     beginTime = timeShift + beginExposureNr * cycleTime;
     endTime   = beginTime + numExposures * cycleTime;
 }


### PR DESCRIPTION
Fixes issue #540. Whenever the time shift if calculated in
Simulation.cpp, JitterFromFile.cpp and ThermoElasticDriftFromFile.cpp,
the shift is 0 if we are dealing with a fast camera.