### PR TITLE
F-Cam implementation

### DIFF
--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -487,6 +487,20 @@ void Detector::updateParameters(double time)
     subFieldZeroPointRow    = configParam.getInteger("SubField/ZeroPointRow");
     subFieldZeroPointColumn = configParam.getInteger("SubField/ZeroPointColumn");
     numRowsPixelMap         = configParam.getInteger("SubField/NumRows");
+    // For a fast camera, the part of the subfield that is on the lower half of the CCD (and thus physically covered) is ignored.
+    // If no part of the subfield lies on the exposed part of the CCD, and error is raised and the simulation is terminated.
+    if (isFastCamera)
+    {
+      numRowsPixelMap       = std::max(0, int(numRowsPixelMap - std::max(0, int(firstRowExposed - subFieldZeroPointRow))));
+      subFieldZeroPointRow  = std::max(subFieldZeroPointRow, firstRowExposed);
+      if (numRowsPixelMap == 0)
+      {
+	Log.error("The subfield does not lie on the exposed part of the detector, nothing is simulated.");
+	exit(1);
+      }
+      
+
+    }
     numColumnsPixelMap      = configParam.getInteger("SubField/NumColumns");
     numRowsBiasMap          = configParam.getInteger("SubField/NumBiasPrescanRows");
     numColumnsBiasMap       = configParam.getInteger("SubField/NumBiasPrescanColumns");

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -409,7 +409,7 @@ pair<double, double> Simulation::configureReadoutTime(ConfigurationParameters &c
 
 		else if (readoutMode == "Partial")
 		{
-            numRowsReadout = configParams.getInteger("CCD/ReadoutMode/Partial/NumRowsReadout");
+		numRowsReadout = configParams.getInteger("CCD/ReadoutMode/Partial/NumRowsReadout");
 			numRowsDump = firstRowExposed - numRowsReadout;
 		}
 


### PR DESCRIPTION
Fixes issue #605. Changed the selection of the subfield when dealing
with Fast-Cameras in `Detector::configure`. When dealing with Fast-Cameras, only the part of the subfield that is
exposed (and not shielded off) is taken into account. When no part of
the subfield is exposed an error is generated and the simulation is
terminated.