### PR TITLE
Dependencies install files checks that Installs directory exists

### DIFF
--- a/dependencies/installscripts/install_armadillo.py
+++ b/dependencies/installscripts/install_armadillo.py
@@ -14,8 +14,15 @@ packageName = "armadillo-6.500.4"
 # Specify build and install folders
 
 currentWorkingDir = os.getcwd()
-buildDir   = currentWorkingDir + "/dependencies/Downloads/"
-installDir = currentWorkingDir + "/dependencies/Installs/" + packageName 
+buildDir         = currentWorkingDir + "/dependencies/Downloads/"
+parentInstallDir = currentWorkingDir + "/dependencies/Installs/"
+installDir = currentWorkingDir + "/dependencies/Installs/" + packageName
+
+
+# Check if /dependencies/Installs directory exists
+
+if not os.path.isdir(parentInstallDir):
+    os.mkdir(parentInstallDir)
 
 # If there is an older version of the install dir, make sure to remove it first.
 

--- a/dependencies/installscripts/install_faddeeva.py
+++ b/dependencies/installscripts/install_faddeeva.py
@@ -14,8 +14,15 @@ packageName = "Faddeeva"
 # Specify build and install folders
 
 currentWorkingDir = os.getcwd()
-buildDir   = currentWorkingDir + "/dependencies/Downloads/"
-installDir = currentWorkingDir + "/dependencies/Installs/" + packageName 
+buildDir         = currentWorkingDir + "/dependencies/Downloads/"
+parentInstallDir = currentWorkingDir + "/dependencies/Installs/"
+installDir = currentWorkingDir + "/dependencies/Installs/" + packageName
+
+
+# Check if /dependencies/Installs directory exists
+
+if not os.path.isdir(parentInstallDir):
+    os.mkdir(parentInstallDir)
 
 # If there is an older version of the install dir, make sure to remove it first.
 

--- a/dependencies/installscripts/install_fftw.py
+++ b/dependencies/installscripts/install_fftw.py
@@ -13,8 +13,16 @@ packageName = "fftw-3.3.4"
 # Specify build and install folders
 
 currentWorkingDir = os.getcwd()
-buildDir   = currentWorkingDir + "/dependencies/Downloads/"
-installDir = currentWorkingDir + "/dependencies/Installs/" + packageName 
+buildDir         = currentWorkingDir + "/dependencies/Downloads/"
+parentInstallDir = currentWorkingDir + "/dependencies/Installs/"
+installDir       = parentInstallDir + packageName 
+
+
+# Check if /dependencies/Installs directory exists
+
+if not os.path.isdir(parentInstallDir):
+    os.mkdir(parentInstallDir)
+
 
 # If there is an older version of the install dir, make sure to remove it first.
 

--- a/dependencies/installscripts/install_googletest.py
+++ b/dependencies/installscripts/install_googletest.py
@@ -14,8 +14,15 @@ packageName = "googletest"
 # Specify build and install folders
 
 currentWorkingDir = os.getcwd()
-buildDir   = currentWorkingDir + "/dependencies/Downloads/"
-installDir = currentWorkingDir + "/dependencies/Installs/" + packageName 
+buildDir         = currentWorkingDir + "/dependencies/Downloads/"
+parentInstallDir = currentWorkingDir + "/dependencies/Installs/"
+installDir = currentWorkingDir + "/dependencies/Installs/" + packageName
+
+
+# Check if /dependencies/Installs directory exists
+
+if not os.path.isdir(parentInstallDir):
+    os.mkdir(parentInstallDir)
 
 # Print a banner
 

--- a/dependencies/installscripts/install_hdf5.py
+++ b/dependencies/installscripts/install_hdf5.py
@@ -14,9 +14,16 @@ packageName = "hdf5-1.12.0"
 # Specify build and install folders
 
 currentWorkingDir = os.getcwd()
-buildDir   = currentWorkingDir + "/dependencies/Downloads/"
-installDir = currentWorkingDir + "/dependencies/Installs/" + packageName 
+buildDir         = currentWorkingDir + "/dependencies/Downloads/"
+parentInstallDir = currentWorkingDir + "/dependencies/Installs/"
+installDir       = parentInstallDir + packageName 
 
+
+# Check if /dependencies/Installs directory exists
+
+if not os.path.isdir(parentInstallDir):
+    os.mkdir(parentInstallDir)
+    
 # Remove a possible older version, and create a fresh one
 
 shutil.rmtree(installDir, ignore_errors=True)
@@ -33,8 +40,8 @@ print("\n")
 # Build and install package
 
 installProcedure = "cd {build};                                     \
-					tar -xzvf {package}.tar.gz;                        \
-					cd {package};                                   \
+                    tar -xzvf {package}.tar.gz;                     \
+                    cd {package};                                   \
                     ./configure --prefix={install} --enable-cxx;    \
                     make;                                           \
                     make install".format(build=buildDir, package=packageName, install=installDir)

--- a/dependencies/installscripts/install_yaml.py
+++ b/dependencies/installscripts/install_yaml.py
@@ -14,8 +14,16 @@ packageName = "yaml-cpp"
 # Specify build and install folders
 
 currentWorkingDir = os.getcwd()
-buildDir   = currentWorkingDir + "/dependencies/Downloads/"
-installDir = currentWorkingDir + "/dependencies/Installs/" + packageName 
+buildDir         = currentWorkingDir + "/dependencies/Downloads/"
+parentInstallDir = currentWorkingDir + "/dependencies/Installs/"
+installDir       = parentInstallDir + packageName 
+
+
+# Check if /dependencies/Installs directory exists
+
+if not os.path.isdir(parentInstallDir):
+    os.mkdir(parentInstallDir)
+
 
 # Print a banner
 

--- a/dependencies/installscripts/install_zeromq.py
+++ b/dependencies/installscripts/install_zeromq.py
@@ -15,8 +15,15 @@ packageName2 = "cppzmq-master"
 # Specify build and install folders
 
 currentWorkingDir = os.getcwd()
-buildDir   = currentWorkingDir + "/dependencies/Downloads/"
+buildDir         = currentWorkingDir + "/dependencies/Downloads/"
+parentInstallDir = currentWorkingDir + "/dependencies/Installs/"
 installDir = currentWorkingDir + "/dependencies/Installs/" + packageName1
+
+
+# Check if /dependencies/Installs directory exists
+
+if not os.path.isdir(parentInstallDir):
+    os.mkdir(parentInstallDir)
 
 
 # If there is an older version of the install dir, make sure to remove it first.

--- a/install.sh
+++ b/install.sh
@@ -13,10 +13,6 @@ set -e
 # dependency package. Each script Unzip/Untar packages in dependencies/Downloads/ 
 # and installs dependencies packages in dependencies/Installs/
 
-if [ ! -d ./dependencies/Installs ]; then
-    mkdir ./dependencies/Installs
-fi
-
 python ./dependencies/installscripts/install_hdf5.py
 python ./dependencies/installscripts/install_googletest.py
 python ./dependencies/installscripts/install_yaml.py


### PR DESCRIPTION
The dependencies install files now check that the `/dependencies/Installs`
directory exists. If the directory doesn't exist the install files
will create them. This fixed issue #625..