### PR TITLE
Included option to switch on/off pointlike and extended ghosts separately 

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,11 +5,17 @@
 ** Improvements
 
 *** Update `showSim.py` to include biasMapsRight and biasMapsLeft
+
 *** New analytic PSF model and set of parameters for N6000K
+
 *** Include more accurate PSF files for mapped PSF model. The new files can be downloaded from the `Prerequisites` section of the PlatoSim website. 
+
 *** Updated mail.cpp to allow a new log level: 0: only shows errors and no warning. 
+
 *** Update `Simulation::writeInputParametersToHDF5` function.
+
 *** Implemented a new mapped distortion method for the mapped PSF model. The distortion table is included in psf files. 
+
 *** Updated website 
 
 
@@ -18,7 +24,9 @@
 ** Bug fixes
 
 *** Fixed issue where timeshift was applied when reading out CCDs for the F-CAMs (GitHub #540)
+
 *** In `hdf5ToFits.py` typecheck before converting to `string` (GitHub #600)
+
 *** Removed fortran dependencies in fftw  install script
 
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,43 +1,29 @@
-* Release Notes PlatoSim 3.4.1
+* Release Notes PlatoSim 3.5.0
 
 
 
 ** Improvements
 
+*** Update `showSim.py` to include biasMapsRight and biasMapsLeft
+*** New analytic PSF model and set of parameters for N6000K
+*** Include more accurate PSF files for mapped PSF model. The new files can be downloaded from the `Prerequisites` section of the PlatoSim website. 
+*** Updated mail.cpp to allow a new log level: 0: only shows errors and no warning. 
+*** Update `Simulation::writeInputParametersToHDF5` function.
+*** Implemented a new mapped distortion method for the mapped PSF model. The distortion table is included in psf files. 
+*** Updated website 
 
-*** Added an option to the method `getYawPitchRoll` in simfile.py to obtain the time (GitHub issue #508)
 
-*** Apply the BFE after full-well saturation (GitHub issue #584)
-The current implementation of the BFE fails for very large pixel values, which results in negative pixel values in
-the pixelmap. By first applying full-well saturation, these large values will not occur.
-
-*** The conda install should now work for python versions 3.6, 3.7, 3.8 and 3.9.
 
 
 ** Bug fixes
 
-*** Corrected the implementation of the jitter/drift from red noise
-The previous implementation of the jitter and drift was not consistent between different CCDs. It is now implemented
-to be consistent between different CCDs if the jitter/drift seed is the same.
+*** Fixed issue where timeshift was applied when reading out CCDs for the F-CAMs (GitHub #540)
+*** In `hdf5ToFits.py` typecheck before converting to `string` (GitHub #600)
+*** Removed fortran dependencies in fftw  install script
 
-*** Fixed conda build of PlatoSim in Jenkins
 
 
     
 ** New features/functionality
 
-*** Validation test for Jitter on different CCDs
-
-*** Add method `getYawPitchRollFromDrift` in simfile.py
-Added a method to extract the Yaw, Pitch, Roll and time from the output file.
-
-*** Option to add the diffused PSF in the output file. (GitHub Issue #564)
-
-*** Add option `setSubfieldAroundPixelRows` (GitHub Issue #587)
-
-*** Added the option to (not) include in the output file:
-    - High resolution PSF (if PSF is not Analytic Gaussian)
-    - Star Catalog
-    - Platform Yaw, Pitch, Roll
-    - Transmission Efficiency
-
+*** Added a more accurate aberration model. Instead of assuming a circular orbit with constant speed around the sun, we can now include the path of the spacecraft in an orbit file to simulate any time-dependent velocity. An accurate orbit file is included in the `inputfiles` directory. 

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -118,7 +118,8 @@ class Camera : public HDF5Writer
         vector<double> transmissionEfficiencyValues;
         double totalSkyBackground;          // Total sky background [photons / pixel / exposure]
 
-        bool includeGhosts;                                         // Whether or not to include ghosts
+        bool includePointLikeGhosts;                                // Whether or not to include pointlike ghosts
+        bool includeExtendedGhosts;                                 // Whether or not to include extended ghosts
         double distanceCutOffPointLikeGhosts;                       // Beyond this distance from the optical axis [degrees], sources don't produce point-like ghosts anymore
         double fluxRatioOnAxisPointLikeGhosts;                      // Flux ratio between the point-like ghost and the originating source on-axis [%] -> linear decrease
         double distanceRatioExtendedGhosts;                         // For a star at FP-coordinates (x, y), the centre of the extended ghost will be at (distanceRatio * x, distanceRatio * y)

--- a/include/DetectorWithMappedPSF.h
+++ b/include/DetectorWithMappedPSF.h
@@ -75,14 +75,13 @@ class DetectorWithMappedPSF : public Detector
         bool writeDiffusedPSF;                  // Whether or not to write the diffused PSF to the output HDF5 file
 
         arma::Mat<float> diffusionKernel;                    // Diffusion kernel image
-        IntegralOfAnalyticSignalResponse signalResponse;	 // Signal response
-        double diffusionKernelWidth;				         // Width (sigma) of the Gaussian diffusion kernel [sub-pixels]
-        int diffusionKernelImageSize;             		     // Size of the diffusion kernel image [sub-pixels]
-
+        IntegralOfAnalyticSignalResponse signalResponse;    // Signal response
+        double diffusionKernelWidth;                        // Width (sigma) of the Gaussian diffusion kernel [sub-pixels]
+        int diffusionKernelImageSize;                           // Size of the diffusion kernel image [sub-pixels]
         unsigned int numRowsSubPixelMap;        // Nr of subpixel rows in the subfield incl. edge pixels (= size in the y-direction) [subpixels]
         unsigned int numColumnsSubPixelMap;     // Nr of subpixel columns in the subfield incl. edge pixels (= size in the x-direction = readout direction) [subpixels]
         unsigned int numSubPixelsPerPixel;      // Nr of sub-pixels per pixel
-        PointSpreadFunction *psf;        
+        PointSpreadFunction *psf;
         long flatfieldSeed;
 
         Convolver convolver;

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -67,7 +67,6 @@ class Simulation
 
         bool useJitter;
         string jitterSource;
-        bool includeFieldDistortion;
         bool useDrift;
         bool useDriftFromFile;
         bool useFeeTemperatureFromFile;

--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -89,7 +89,8 @@ Camera:
         ConstantInverseCoefficients: [-0.317143032936, 0.242638513347,-0.459260203502]       # In case Source is ConstantValue
         CoefficientsFromFile:        inputfiles/distortioncoefficients.txt                   # In case Source is FromFile
         InverseCoefficientsFromFile: inputfiles/distortioninversecoefficients.txt            # In case Source if FromFile
-    IncludeGhosts:                   yes
+    IncludePointLikeGhosts:          yes
+    IncludeExtendedGhosts:           no
     Ghosts:
         PointLike:
             FluxRatio:               0.08                       # Flux ratio between the point-like ghost and the originating source [%]

--- a/python/platosim/validation.py
+++ b/python/platosim/validation.py
@@ -65,7 +65,8 @@ def switchOffAllEffects(sim):
 
     sim["Camera/IncludeAberrationCorrection"] = "no"
     sim["Camera/IncludeFieldDistortion"] = "no"
-    sim["Camera/IncludeGhosts"] = "no"
+    sim["Camera/IncludePointLikeGhosts"] = "no"
+    sim["Camera/IncludeExtendedGhosts"]  = "no"
 
     # PSF parameters
 

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -307,11 +307,13 @@ void Camera::flushOutput()
 
     // If the ghost option was set, also write for each exposure the info of the ghost stars to the HDF5 file.
 
-    if (includeGhosts && writeGhostPositions)
+    if ((includePointLikeGhosts || includeExtendedGhosts) && writeGhostPositions)
     {
+      vector<double> time;
+      if(includePointLikeGhosts)
+      {
         Log.info("Camera: writing pointlike ghost positions to HDF5 file");
 
-        vector<double> time;
         for(auto keyValuePair: detectedPointLikeGhostInfo) time.push_back(keyValuePair.first);
         if (!time.empty())
         {
@@ -323,118 +325,124 @@ void Camera::flushOutput()
         }
 
         for (int n = 0; n < time.size(); n++)
-        {
-            stringstream myStream;
-            myStream << "Exposure" << setfill('0') << setw(6) << beginExposureNr + n;
+	{
+	  stringstream myStream;
+	  myStream << "Exposure" << setfill('0') << setw(6) << beginExposureNr + n;
+	  
+	  // Write the info for the point-like ghost star positions to HDF5
 
-            // Write the info for the point-like ghost star positions to HDF5
+	  vector<unsigned int> starIDs;
+	  vector<double> xFPmm;
+	  vector<double> yFPmm;
+	  vector<double> rowPix;
+	  vector<double> colPix;
+	  vector<double> flux;
+	  vector<double> ghostRadius;
+	  
+	  for(auto keyValuePair: detectedPointLikeGhostInfo[time[n]])
+	  {
+	    const unsigned int starID = keyValuePair.first;
+	    starIDs.push_back(starID);                       // list of starIDs for this exposure only
+	    xFPmm.push_back(detectedPointLikeGhostInfo[time[n]][starID][0] / detectedPointLikeGhostInfo[time[n]][starID][5]);
+	    yFPmm.push_back(detectedPointLikeGhostInfo[time[n]][starID][1] / detectedPointLikeGhostInfo[time[n]][starID][5]);
+	    rowPix.push_back(detectedPointLikeGhostInfo[time[n]][starID][2] / detectedPointLikeGhostInfo[time[n]][starID][5]);
+	    colPix.push_back(detectedPointLikeGhostInfo[time[n]][starID][3] / detectedPointLikeGhostInfo[time[n]][starID][5]);
+	    flux.push_back(detectedPointLikeGhostInfo[time[n]][starID][4]);
+	  }
 
-            vector<unsigned int> starIDs;
-            vector<double> xFPmm;
-            vector<double> yFPmm;
-            vector<double> rowPix;
-            vector<double> colPix;
-            vector<double> flux;
-            vector<double> ghostRadius;
+	  const string pointLikeGhostGroupName = "/PointLikeGhostPositions/" + myStream.str();
+	  hdf5File.createGroup(pointLikeGhostGroupName);
+	    
+	  if(!starIDs.empty())
+	  {
+	    hdf5File.writeArray(pointLikeGhostGroupName, "starID", starIDs.data(), starIDs.size());
+	    hdf5File.writeArray(pointLikeGhostGroupName, "xFPmm",  xFPmm.data(),   xFPmm.size());
+	    hdf5File.writeArray(pointLikeGhostGroupName, "yFPmm",  yFPmm.data(),   yFPmm.size());
+	    hdf5File.writeArray(pointLikeGhostGroupName, "rowPix", rowPix.data(),  rowPix.size());
+	    hdf5File.writeArray(pointLikeGhostGroupName, "colPix", colPix.data(),  colPix.size());
+	    hdf5File.writeArray(pointLikeGhostGroupName, "flux",   flux.data(),    flux.size());
+	  }
+	
 
-            for(auto keyValuePair: detectedPointLikeGhostInfo[time[n]])
-            {
-                const unsigned int starID = keyValuePair.first;
-                starIDs.push_back(starID);                       // list of starIDs for this exposure only
-                xFPmm.push_back(detectedPointLikeGhostInfo[time[n]][starID][0] / detectedPointLikeGhostInfo[time[n]][starID][5]);
-                yFPmm.push_back(detectedPointLikeGhostInfo[time[n]][starID][1] / detectedPointLikeGhostInfo[time[n]][starID][5]);
-                rowPix.push_back(detectedPointLikeGhostInfo[time[n]][starID][2] / detectedPointLikeGhostInfo[time[n]][starID][5]);
-                colPix.push_back(detectedPointLikeGhostInfo[time[n]][starID][3] / detectedPointLikeGhostInfo[time[n]][starID][5]);
-                flux.push_back(detectedPointLikeGhostInfo[time[n]][starID][4]);
-            }
+	  // Write the info for the point like ghost star positions to HDF5
 
-            const string pointLikeGhostGroupName = "/PointLikeGhostPositions/" + myStream.str();
-            hdf5File.createGroup(pointLikeGhostGroupName);
+	  Log.info("Camera: writing point like ghost positions to HDF5 file");
+	  
+	  starIDs.clear();
+	  xFPmm.clear();
+	  yFPmm.clear();
+	  rowPix.clear();
+	  colPix.clear();
+	  flux.clear();
+	  ghostRadius.clear();
+	}
+      }
 
-            if(!starIDs.empty())
-            {
-                hdf5File.writeArray(pointLikeGhostGroupName, "starID", starIDs.data(), starIDs.size());
-                hdf5File.writeArray(pointLikeGhostGroupName, "xFPmm",  xFPmm.data(),   xFPmm.size());
-                hdf5File.writeArray(pointLikeGhostGroupName, "yFPmm",  yFPmm.data(),   yFPmm.size());
-                hdf5File.writeArray(pointLikeGhostGroupName, "rowPix", rowPix.data(),  rowPix.size());
-                hdf5File.writeArray(pointLikeGhostGroupName, "colPix", colPix.data(),  colPix.size());
-                hdf5File.writeArray(pointLikeGhostGroupName, "flux",   flux.data(),    flux.size());
-            }
+      time.clear();
+      
+      if(includeExtendedGhosts)
+      {
+	for(auto keyValuePair: detectedExtendedGhostInfo) time.push_back(keyValuePair.first);
+	if (!time.empty())
+	{
+	  hdf5File.writeArray("ExtendedGhostPositions/", "Time", time.data(), time.size());
+	}
+	else
+	{
+	  Log.warning("Camera: No extended ghost positions to write to HDF5 file.");
+	}
+	
+	for (int n = 0; n < time.size(); n++)
+	{
+	  stringstream myStream;
+	  myStream << "Exposure" << setfill('0') << setw(6) << beginExposureNr + n;
+	    
+	    
+	  // Write the info for the extended ghost star positions to HDF5
+	  
+	  vector<unsigned int> starIDs;
+	  vector<double> xFPmm;
+	  vector<double> yFPmm;
+	  vector<double> rowPix;
+	  vector<double> colPix;
+	  vector<double> flux;
+	  vector<double> ghostRadius;
+	      
+	    
+	  for(auto keyValuePair: detectedExtendedGhostInfo[time[n]])
+	  {
+	    const unsigned int starID = keyValuePair.first;
+	    starIDs.push_back(starID);                       // list of starIDs for this exposure only
+	    xFPmm.push_back(detectedExtendedGhostInfo[time[n]][starID][0] / detectedExtendedGhostInfo[time[n]][starID][5]);
+	    yFPmm.push_back(detectedExtendedGhostInfo[time[n]][starID][1] / detectedExtendedGhostInfo[time[n]][starID][5]);
+	    rowPix.push_back(detectedExtendedGhostInfo[time[n]][starID][2] / detectedExtendedGhostInfo[time[n]][starID][5]);
+	    colPix.push_back(detectedExtendedGhostInfo[time[n]][starID][3] / detectedExtendedGhostInfo[time[n]][starID][5]);
+	    flux.push_back(detectedExtendedGhostInfo[time[n]][starID][4]);
+	    ghostRadius.push_back(detectedExtendedGhostInfo[time[n]][starID][6] / detectedExtendedGhostInfo[time[n]][starID][5]);
+	  }
+	  
+	  const string extendedGhostGroupName = "/ExtendedGhostPositions/" + myStream.str();
+	  hdf5File.createGroup(extendedGhostGroupName);
+	    
+	  if(!starIDs.empty())
+	  {
+	    hdf5File.writeArray(extendedGhostGroupName, "starID", starIDs.data(), starIDs.size());
+	    hdf5File.writeArray(extendedGhostGroupName, "xFPmm",  xFPmm.data(),   xFPmm.size());
+	    hdf5File.writeArray(extendedGhostGroupName, "yFPmm",  yFPmm.data(),   yFPmm.size());
+	    hdf5File.writeArray(extendedGhostGroupName, "rowPix", rowPix.data(),  rowPix.size());
+	    hdf5File.writeArray(extendedGhostGroupName, "colPix", colPix.data(),  colPix.size());
+	    hdf5File.writeArray(extendedGhostGroupName, "flux",   flux.data(),    flux.size());
+	    hdf5File.writeArray(extendedGhostGroupName, "radius", ghostRadius.data(), ghostRadius.size());
+	  }
+	}
+      }
+    }
 
 
-            // Write the info for the extended ghost star positions to HDF5
 
-            Log.info("Camera: writing extended ghost positions to HDF5 file");
-
-            starIDs.clear();
-            xFPmm.clear();
-            yFPmm.clear();
-            rowPix.clear();
-            colPix.clear();
-            flux.clear();
-            ghostRadius.clear();
-        }
-
-        time.clear();
-        for(auto keyValuePair: detectedExtendedGhostInfo) time.push_back(keyValuePair.first);
-        if (!time.empty())
-        {
-            hdf5File.writeArray("ExtendedGhostPositions/", "Time", time.data(), time.size());
-        }
-        else
-        {
-            Log.warning("Camera: No extended ghost positions to write to HDF5 file.");
-        }
-
-        for (int n = 0; n < time.size(); n++)
-        {
-            stringstream myStream;
-            myStream << "Exposure" << setfill('0') << setw(6) << beginExposureNr + n;
-
-
-            // Write the info for the extended ghost star positions to HDF5
-
-            vector<unsigned int> starIDs;
-            vector<double> xFPmm;
-            vector<double> yFPmm;
-            vector<double> rowPix;
-            vector<double> colPix;
-            vector<double> flux;
-            vector<double> ghostRadius;
-
-
-            for(auto keyValuePair: detectedExtendedGhostInfo[time[n]])
-            {
-                const unsigned int starID = keyValuePair.first;
-                starIDs.push_back(starID);                       // list of starIDs for this exposure only
-                xFPmm.push_back(detectedExtendedGhostInfo[time[n]][starID][0] / detectedExtendedGhostInfo[time[n]][starID][5]);
-                yFPmm.push_back(detectedExtendedGhostInfo[time[n]][starID][1] / detectedExtendedGhostInfo[time[n]][starID][5]);
-                rowPix.push_back(detectedExtendedGhostInfo[time[n]][starID][2] / detectedExtendedGhostInfo[time[n]][starID][5]);
-                colPix.push_back(detectedExtendedGhostInfo[time[n]][starID][3] / detectedExtendedGhostInfo[time[n]][starID][5]);
-                flux.push_back(detectedExtendedGhostInfo[time[n]][starID][4]);
-                ghostRadius.push_back(detectedExtendedGhostInfo[time[n]][starID][6] / detectedExtendedGhostInfo[time[n]][starID][5]);
-            }
-        
-            const string extendedGhostGroupName = "/ExtendedGhostPositions/" + myStream.str();
-            hdf5File.createGroup(extendedGhostGroupName);
-        
-            if(!starIDs.empty())
-            {
-                hdf5File.writeArray(extendedGhostGroupName, "starID", starIDs.data(), starIDs.size());
-                hdf5File.writeArray(extendedGhostGroupName, "xFPmm",  xFPmm.data(),   xFPmm.size());
-                hdf5File.writeArray(extendedGhostGroupName, "yFPmm",  yFPmm.data(),   yFPmm.size());
-                hdf5File.writeArray(extendedGhostGroupName, "rowPix", rowPix.data(),  rowPix.size());
-                hdf5File.writeArray(extendedGhostGroupName, "colPix", colPix.data(),  colPix.size());
-                hdf5File.writeArray(extendedGhostGroupName, "flux",   flux.data(),    flux.size());
-                hdf5File.writeArray(extendedGhostGroupName, "radius", ghostRadius.data(), ghostRadius.size());
-            }
-        }
-    } 
-
-    
 
     // Write the total sky background flux values [photons/pixel/exposure] to HDF5 in a custom group
-
+    
     hdf5File.writeArray("Background/", "skyBackground", skyBackgroundValues.data(), skyBackgroundValues.size());
 
     // Write the transmissionEfficiency values for each exposureTime to HDF5 in a custom group
@@ -575,20 +583,42 @@ void Camera::configure(ConfigurationParameters &configParam)
 
     // Configure the ghost star parameters 
 
-    includeGhosts = configParam.getBoolean("Camera/IncludeGhosts");
+    includePointLikeGhosts = configParam.getBoolean("Camera/IncludePointLikeGhosts");
+    includeExtendedGhosts  = configParam.getBoolean("Camera/IncludeExtendedGhosts");
 
-    if(includeGhosts)
+    if(includePointLikeGhosts)
     {
         distanceCutOffPointLikeGhosts = deg2rad(configParam.getDouble("Camera/Ghosts/PointLike/DistanceCutOff"));   // [radians]
         fluxRatioOnAxisPointLikeGhosts = configParam.getDouble("Camera/Ghosts/PointLike/FluxRatio") / 100.0;
-        distanceRatioExtendedGhosts = configParam.getDouble("Camera/Ghosts/Extended/DistanceRatio");
-        fluxRatioExtendedGhosts = configParam.getDouble("Camera/Ghosts/Extended/FluxRatio") / 100.0;
 
-        vector<double> extendedGhostRadiusCoefVector = configParam.getDoubleVector("Camera/Ghosts/Extended/RadiusCoefficients");
-        array<double, 3> extendedGhostRadiusCoefArray;
-        copy(extendedGhostRadiusCoefVector.begin(), extendedGhostRadiusCoefVector.end(), extendedGhostRadiusCoefArray.begin());
+	if(includeExtendedGhosts)
+	{
+	  distanceRatioExtendedGhosts = configParam.getDouble("Camera/Ghosts/Extended/DistanceRatio");
+	  fluxRatioExtendedGhosts = configParam.getDouble("Camera/Ghosts/Extended/FluxRatio") / 100.0;
 
-        extendedGhostRadiusCoefficients = new Parameter<double, 3>(extendedGhostRadiusCoefArray);
+	  vector<double> extendedGhostRadiusCoefVector = configParam.getDoubleVector("Camera/Ghosts/Extended/RadiusCoefficients");
+	  array<double, 3> extendedGhostRadiusCoefArray;
+	  copy(extendedGhostRadiusCoefVector.begin(), extendedGhostRadiusCoefVector.end(), extendedGhostRadiusCoefArray.begin());
+
+	  extendedGhostRadiusCoefficients = new Parameter<double, 3>(extendedGhostRadiusCoefArray);
+	}
+	else
+	{
+	  Log.info("Camera: Ignoring Extended Ghosts");
+	}
+    }
+    else if(includeExtendedGhosts)
+    {
+      Log.info("Camera: Ignoring Point Like Ghosts");
+
+      distanceRatioExtendedGhosts = configParam.getDouble("Camera/Ghosts/Extended/DistanceRatio");
+      fluxRatioExtendedGhosts = configParam.getDouble("Camera/Ghosts/Extended/FluxRatio") / 100.0;
+
+      vector<double> extendedGhostRadiusCoefVector = configParam.getDoubleVector("Camera/Ghosts/Extended/RadiusCoefficients");
+      array<double, 3> extendedGhostRadiusCoefArray;
+      copy(extendedGhostRadiusCoefVector.begin(), extendedGhostRadiusCoefVector.end(), extendedGhostRadiusCoefArray.begin());
+
+      extendedGhostRadiusCoefficients = new Parameter<double, 3>(extendedGhostRadiusCoefArray);	
     }
     else
     {
@@ -713,7 +743,7 @@ void Camera::exposeDetectorWithStars(Detector &detector, double startTime, doubl
         detector.updateParameters(internalTime);
         sky.updateParameters(internalTime);
 
-        if(includeGhosts)
+        if(includeExtendedGhosts)
             coefficients = (*extendedGhostRadiusCoefficients)();
 
         // Loop over the selected stars and add their flux to the sub-fild
@@ -790,7 +820,7 @@ void Camera::exposeDetectorWithStars(Detector &detector, double startTime, doubl
                 }
             }
 
-            if(includeGhosts)
+            if(includeExtendedGhosts)
             {
                 // Focal-plane coordinates of the centre of the extended ghost
 
@@ -846,7 +876,7 @@ void Camera::exposeDetectorWithStars(Detector &detector, double startTime, doubl
             }
         }
 
-        if(includeGhosts)
+        if(includePointLikeGhosts)
         {
             // Loop over the selected originators of symmetric point-like ghosts and
             // add their flux to the sub-field (if enabled)
@@ -1054,7 +1084,7 @@ tuple<unsigned long, unsigned long> Camera::makeStarCatalogSelection(Detector &d
 
     unsigned long numPointLikeGhosts = 0;
 
-    if(includeGhosts)
+    if(includePointLikeGhosts)
     {
         // Apply the same procedure for the originators of symmetric point-like ghosts on or near
         // the sub-field
@@ -1085,7 +1115,7 @@ tuple<unsigned long, unsigned long> Camera::makeStarCatalogSelection(Detector &d
         Log.info("Camera: applying " + aberrationCorrectionType + " aberration correction to the selected stars.");
         sky.aberrateSelectedStarPositions(platform, aberrationCorrectionType, startTime, timeMiddle);
 
-        if(includeGhosts)
+        if(includePointLikeGhosts)
         {
             Log.info("Camera: applying " + aberrationCorrectionType + " aberration correction to the selected originators of symmetrical point-like ghosts.");
             sky.aberrateSelectedGhostOrigPositions(platform, aberrationCorrectionType, startTime, timeMiddle);

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -221,8 +221,8 @@ void DetectorWithMappedPSF::generateFlatfieldMap()
     // Double the dimensions (this is necessary because of the behaviour of the Fourier transforms)
     // (this is a bit inconvenient as we are working at sub-pixel level -> to be investigated)
 
-    int Nrows = 2 * numRowsPixelMap * numSubPixelsPerPixel;
-    int Ncolumns = 2 * numColumnsPixelMap * numSubPixelsPerPixel;
+    unsigned int Nrows = 2 * numRowsPixelMap * numSubPixelsPerPixel;
+    unsigned int Ncolumns = 2 * numColumnsPixelMap * numSubPixelsPerPixel;
 
     arma::cx_fmat evenMap = arma::cx_fmat(Nrows, Ncolumns);
 
@@ -991,7 +991,8 @@ void DetectorWithMappedPSF::applyDiffusionKernelOnPSF(double subpixRow, double s
  */
 void DetectorWithMappedPSF::applyDistortion(double &x, double &y)
 {
-  double xDist, yDist;
+  double xDist = 0;
+  double yDist = 0;
   double minDistanceSquared = std::numeric_limits<double>::max();
 
   for (auto& coordinates : distortionMap)
@@ -1018,7 +1019,8 @@ void DetectorWithMappedPSF::applyDistortion(double &x, double &y)
  */
 void DetectorWithMappedPSF::applyInverseDistortion(double &x, double &y)
 {
-  double xUndist, yUndist;
+  double xUndist = 0;
+  double yUndist = 0;
   double minDistanceSquared = std::numeric_limits<double>::max();
 
   for (auto& coordinates : distortionMap)

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -73,7 +73,7 @@ void Logger::emit(string message, LogLevel logLevel)
 
 	if (outputStreams.size() != 0)
 	{
-    	for (int n = 0; n < outputStreams.size(); ++n)
+    	for (unsigned int n = 0; n < outputStreams.size(); ++n)
     	{
     		if (outputStreamLogLevel[n] & logLevel & enabledLogLevels)
     		{

--- a/source/PointSpreadFunction.cpp
+++ b/source/PointSpreadFunction.cpp
@@ -236,7 +236,7 @@ void PointSpreadFunction::select(double xFP, double yFP)
 
     
 
-    for (int i=0; i < xDistorted.size(); i++)
+    for (unsigned int i=0; i < xDistorted.size(); i++)
     {
       const std::array<double, 4> coordinates = { xUndistorted.at(i), yUndistorted.at(i), xDistorted.at(i), yDistorted.at(i) }; 
       distortionMap.push_back(coordinates);

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -735,7 +735,8 @@ void Simulation::writeInputParametersToHDF5(ConfigurationParameters &configParam
     addDouble("PlateScale");
     addDouble("ThroughputBandwidth");
     addDouble("ThroughputLambdaC");
-    addBoolean("IncludeGhosts");
+    addBoolean("IncludePointLikeGhosts");
+    addBoolean("IncludeExtendedGhosts");
     subGroup = "Camera/FocalPlaneOrientation";
     hdf5File->createGroup(parentGroup + "/" + subGroup);
     addString("Source");

--- a/source/Sky.cpp
+++ b/source/Sky.cpp
@@ -470,7 +470,7 @@ void Sky::aberrateSelectedStarPositions(Platform &platform, string aberrationCor
     valarray<double> v = std::get<1>(orbitDB.at(0));
     double speed = std::get<2>(orbitDB.at(0));
  
-    for (int i=0; i < orbitDB.size(); i++)
+    for (unsigned int i=0; i < orbitDB.size(); i++)
     {
       if ( std::get<0>(orbitDB.at(i)) <= time0 + startTime)
       {
@@ -605,7 +605,7 @@ void Sky::aberrateSelectedGhostOrigPositions(Platform &platform, string aberrati
     valarray<double> v = std::get<1>(orbitDB.at(0));
     double speed = std::get<2>(orbitDB.at(0));
  
-    for (int i=0; i < orbitDB.size(); i++)
+    for (unsigned int i=0; i < orbitDB.size(); i++)
     {
       if ( std::get<0>(orbitDB.at(i)) <= time0 + startTime)
       {

--- a/source/SkyCoordinates.cpp
+++ b/source/SkyCoordinates.cpp
@@ -308,7 +308,7 @@ vector<double> angularDistanceBetween(const double RA0, const double dec0, const
 {
     vector<double> angularDistance(RA.size());
 
-    for (long n = 0; n < RA.size(); ++n)
+    for (unsigned long n = 0; n < RA.size(); ++n)
     {
         const double sinHalfDeltaLong = sin((RA0 - RA[n])/2.0);
         const double sinHalfDeltaLat = sin((dec0 - dec[n])/2.0);


### PR DESCRIPTION
It is now possible to switch extended and pointlike ghosts on/off from the input.yaml file. The calculation of the extended ghosts is time-consuming and the effect is very small. For some calculations, it might be useful to still be able to include pointlike ghosts without including extended ghosts. 

The release notes file has also been updated for release 3.5.0 and some compiler warnings have been addressed in the code. 