### PR TITLE
Rotated diffused PSF that gets saved in output hdf5 file

### DIFF
--- a/include/DetectorWithMappedPSF.h
+++ b/include/DetectorWithMappedPSF.h
@@ -10,6 +10,7 @@
 
 #include "Detector.h"
 #include "PointSpreadFunction.h"
+#include "ArrayOperations.h"
 
 using namespace std;
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -910,7 +910,7 @@ void DetectorWithMappedPSF::writeSubPixelMapToHDF5(int exposureNr)
 
 
 /** 
- * \brief: Write the diffused PSF to the HDF5 file.
+ * \brief: Write the diffused and rotated PSF to the HDF5 file.
  */
 
 void DetectorWithMappedPSF::writeDiffusedPSFToHDF5(PointSpreadFunction *psf)
@@ -937,6 +937,11 @@ void DetectorWithMappedPSF::writeDiffusedPSFToHDF5(PointSpreadFunction *psf)
     // reset the diffusion kernel
     generateDiffusionKernel(chargeDiffusionStrength*numSubPixelsPerPixel);
 
+
+    // rotate the diffused PSF
+    diffusedPsf = ArrayOperations::rotateArray(diffusedPsf, -rotationAnglePsf);
+    diffusedPsf /= arma::accu(diffusedPsf);
+   
     // write the diffused psf to the output hdf5 file
     hdf5File.writeArray("/PSF", "diffusedPSF", diffusedPsf);
 }


### PR DESCRIPTION
Before the diffused PSF got saved without taking rotation (from the
CCD) into account.

Now the diffused PSF that is saved has been rotated. This should fix issue #627.