### PR TITLE
Fixed bug in Simfile.cpp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 
 ## Fixed
 * The diffused PSF that was saved to the output HDF5 is now rotated with respect to the CCD it falls on. (GitHub #627)
+* Fixed bug where the star coordinates where written to the output HDF5 file without taking field distortion into account. (GitHub #631)
 
 ## Changed
 * The dependencies python install files now check that the `Installs` directory excists and creates this directory if it doesn't. 
+* Made the log files for `Camera::makeStarCatalogSelection` clearer. 
 
 ## Added
 * Added an option to individually switch on/off extended or pointlike ghosts. 

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -67,6 +67,7 @@ class Simulation
 
         bool useJitter;
         string jitterSource;
+        bool includeFieldDistortion;
         bool useDrift;
         bool useDriftFromFile;
         bool useFeeTemperatureFromFile;

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -242,6 +242,7 @@ void Simulation::configure(ConfigurationParameters &configParams)
     numExposures                    = configParams.getInteger("ObservingParameters/NumExposures");
     useJitter                       = configParams.getBoolean("Platform/UseJitter");
     jitterSource                    = configParams.getString("Platform/JitterSource");
+    includeFieldDistortion          = configParams.getBoolean("Camera/IncludeFieldDistortion"); // do we want to do this or should this be asked to Camera?
     useDrift                        = configParams.getBoolean("Telescope/UseDrift");  
     useDriftFromFile                = configParams.getBoolean("Telescope/UseDriftFromFile");  
     psfModel                        = configParams.getString("PSF/Model");
@@ -590,6 +591,17 @@ void Simulation::writeStarCatalogToHDF5()
             RA[k]  *= Angle::degrees;    // [rad] -> [deg]
             dec[k] *= Angle::degrees;    // [rad] -> [deg]
 
+	    if (includeFieldDistortion)
+	    {
+	      if(psfModel == "MappedFromFile")
+	      {
+		detector->applyDistortion(xFPmm[k], yFPmm[k]);
+	      }
+	      else
+	      {
+		tie(xFPmm[k], yFPmm[k]) = camera->undistortedToDistortedFocalPlaneCoordinates(xFPmm[k], yFPmm[k]);
+	      }
+	    }
 
             tie(rowPix[k], colPix[k]) = detector->focalPlaneToPixelCoordinates(xFPmm[k], yFPmm[k]);
             k++;


### PR DESCRIPTION
When the star coordinates got written to the output HDF5 file, field distortion was not taken into account. The issue has been fixed by distorting the FP coordinates correctly. This should fix issue #631.