### PR TITLE
Changed how CCD pixel coordinates are rounded

### DIFF
--- a/python/platosim/referenceFrames.py
+++ b/python/platosim/referenceFrames.py
@@ -1466,8 +1466,8 @@ def calculateSubfieldAroundCoordinates(subfieldSizeX, subfieldSizeY, raStar, dec
     # If the star does fall on a CCD, check if it's not too close to the edge for the subfield to
     # be completely on the CCD.
 
-    xCCDpix = round(xCCDpix)                # integer values
-    yCCDpix = round(yCCDpix)
+    xCCDpix = int(xCCDpix)                  # integer values
+    yCCDpix = int(yCCDpix)
     firstRow = CCD[ccdCode]["firstRow"]     # different from nominal than for fast cams
     Ncols = CCD[ccdCode]["Ncols"]
     Nrows = CCD[ccdCode]["Nrows"]

--- a/python/platosim/simulation.py
+++ b/python/platosim/simulation.py
@@ -734,8 +734,8 @@ class Simulation(object):
         else:
             self["CCD/FirstRowExposed"] = str(0)
 
-        self["SubField/ZeroPointRow"] = str(int(yPix - subfieldSizeY/2))
-        self["SubField/ZeroPointColumn"] = str(int(xPix - subfieldSizeX/2))
+        self["SubField/ZeroPointRow"] = str(yPix - int(subfieldSizeY/2))
+        self["SubField/ZeroPointColumn"] = str(xPix - int(subfieldSizeX/2))
         self["SubField/NumRows"] = str(subfieldSizeY)
         self["SubField/NumColumns"] = str(subfieldSizeX)
 


### PR DESCRIPTION
In the function calculateSubfieldAroundCoordiantes of
referenceFrames.py the pixel CCD coordinates are converted to int
using the int() function instead of the previously used round()
function. Because of this we are sure this values is rounded down to
the lower int instead of the nearest int.

We also change in simulation.py the method
setSubfieldAroundCoordinates how the zeroPointRow/Column is set so
that the target is always in the center of the subfield.

Solves issue #678. 