### PR TITLE
Removed custom CCD warning in input files and changed cycleTime

### DIFF
--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -152,7 +152,6 @@ CCD:
 
     Position:                        Custom          # one of [1, 2, 3, 4, Custom]
                                                      # (use Custom to specify the CCD position parameters yourself)
-                                                     # REMARK: if Custom, then Camera/GroupID can not be Fast
 
     OriginOffsetX:                   0               # X Offset of CCD origin from center of focal plane [mm]
     OriginOffsetY:                   0               # Y Offset of CCD origin from center of focal plane [mm]

--- a/inputfiles/inputfileFast.yaml
+++ b/inputfiles/inputfileFast.yaml
@@ -11,7 +11,7 @@ ObservingParameters:
     MissionDuration:                 6.5             # Total duration of the mission [yr], relevant for BOL->EOL degradation
     NumExposures:                    10              # Number of exposures
     BeginExposureNr:                  0              # Sequential number of first exposure. useful for slurm parallellisation
-    CycleTime:                       25              # Image cycle time (exposure + readout before next exposure starts)[s]
+    CycleTime:                       2.5              # Image cycle time (exposure + readout before next exposure starts)[s]
     RApointing:                      86.8            # Platform (not telescope) right ascension pointing coordinate      [deg]
     DecPointing:                     -46.4           # Platform (not telescope) declination pointing coordinate          [deg]
     Fluxm0:                          1.00179e8       # Photon flux of a V=0 G2V-star                                     [phot/s/m^2/nm]
@@ -152,7 +152,6 @@ CCD:
 
     Position:                        Custom          # one of [1, 2, 3, 4, Custom]
                                                      # (use Custom to specify the CCD position parameters yourself)
-                                                     # REMARK: if Custom, then Camera/GroupID can not be Fast
 
     OriginOffsetX:                   0               # X Offset of CCD origin from center of focal plane [mm]
     OriginOffsetY:                   0               # Y Offset of CCD origin from center of focal plane [mm]


### PR DESCRIPTION
Removed warning when CCD is Custom for F-Camera
Changed cycleTime to 2.5 for inputfileFast.yaml

Relates to Issue #605 