### PR TITLE
Fixed bug in which coveredLeft/coveredTop were not initialized

### DIFF
--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -326,8 +326,8 @@ void Detector::updateParameters(double time)
         numRows                = configParam.getInteger("CCD/NumRows");             // [pixels]
         numColumns             = configParam.getInteger("CCD/NumColumns");          // [pixels]
         firstRowExposed        = configParam.getInteger("CCD/FirstRowExposed");     // [pixels]
-        coveredLeft, coveredRight = 0;                                              // [pixels]
-        coveredTop, coveredBottom = 0;                                              // [pixels]
+        coveredLeft = 0, coveredRight = 0;                                          // [pixels]
+        coveredTop = 0, coveredBottom = 0;                                          // [pixels]
 
         rotationAnglePsf = customOrientationAngle;  // Angle over which the PSF should be rotated
 
@@ -369,8 +369,8 @@ void Detector::updateParameters(double time)
 
         rotationAnglePsf = deg2rad(orientation[idx]);  // Angle over which the PSF should be rotated
 
-        coveredLeft, coveredRight = 0;
-        coveredTop, coveredBottom = 0;
+        coveredLeft = 0, coveredRight = 0;
+        coveredTop = 0, coveredBottom = 0;
 
         if (isFastCamera)
         {


### PR DESCRIPTION
In Detector.cpp the variables coveredLeft and coveredTop were not
properly initialized. This sometimes caused random behaviour where it
seemed like the subfield was (completely) covered.

This should fix issue #686.