### PR TITLE
New feature of saving high res analytic non-Gaussian PSF to HDF5

### DIFF
--- a/include/DetectorWithAnalyticNonGaussianPSF.h
+++ b/include/DetectorWithAnalyticNonGaussianPSF.h
@@ -16,7 +16,6 @@
 #include "Detector.h"
 #include "Camera.h"
 #include "Parameter.h"
-#include "PointSpreadFunction.h"
 
 
 
@@ -29,32 +28,33 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
     public:
 
         DetectorWithAnalyticNonGaussianPSF(ConfigurationParameters &configParam, HDF5File &hdf5File, Camera &camera, TemperatureGenerator &feeTemperatureGenerator, TemperatureGenerator &detectorTemperatureGenerator, double readoutTimeBeforeNextExposure, double readoutTimeDuringNextExposure);
-        virtual ~DetectorWithAnalyticNonGaussianPSF();
+        ~DetectorWithAnalyticNonGaussianPSF();
 
-        virtual double takeExposure(int exposureNr, double startTime, double exposureTime) override;
+        double takeExposure(int exposureNr, double startTime, double exposureTime) override;
 
         void configure(ConfigurationParameters &configParam);
-        virtual void updateParameters(double time) override;
-
+        void updateParameters(double time) override;
         bool addFluxToMap(arma::Mat<float>& map, double row0, double col0, double r, double p, double flux);
-        virtual tuple<bool, double, double> addFlux(double xFP, double yFP, double flux) override;
-        virtual void addFlux(double flux) override;
-        virtual tuple<bool, double, double> addExtendedGhost(double xFP, double yFP, double radius, double flux) override;
+
+        tuple<bool, double, double> addFlux(double xFP, double yFP, double flux) override;
+        void addFlux(double flux) override;
+        tuple<bool, double, double> addExtendedGhost(double xFP, double yFP, double radius, double flux) override;
 
         void integrateAnalyticPSF(IntegralOfAnalyticSignalResponse&, double, double, double, double, double, int = 1);
-
-        void makeHighResolutionPSF(arma::Mat<float> &highResMap, int Npixels, int Nsubpixels);
+        void makeHighResolutionPSF(arma::Mat<float> &highResMap, bool includeDiffusion, int Npixels, int Nsubpixels);
         void generateDiffusionKernel(double kernelWidth);
         void applyDiffusionKernelOnPSF(double subpixRow, double subpixColumn, double flux, arma::fmat& psf, int numberOfPsfSubpixelsPerPixel);
-        virtual void flushOutput() override;
+        void flushOutput() override;
 
+        // Photometry
+  
         void applyPhotometry(const unsigned int exposureNr);
 
     protected:
 
-        virtual void integrateLight(int exposureNr, double startTime, double exposureTime) override;
-        virtual void applyFlatfield() override;
-        virtual void generateFlatfieldMap();
+        void integrateLight(int exposureNr, double startTime, double exposureTime) override;
+        void applyFlatfield() override;
+        void generateFlatfieldMap();
 
         Parameter<double> *sigma;           // Width of the analytic PSF, equal to sigma for a Gaussian PSF
         vector<vector<double>> params;      // Table of analytic PSF parameters
@@ -74,7 +74,6 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
         IntegralOfAnalyticSignalResponse signalResponse;    // Signal response
         double diffusionKernelWidth;                        // Width (sigma) of the Gaussian diffusion kernel [sub-pixels]
         int diffusionKernelImageSize;                       // Size of the diffusion kernel image [sub-pixels]
-        PointSpreadFunction *psf;
 
         // Photometry
   

--- a/include/DetectorWithAnalyticNonGaussianPSF.h
+++ b/include/DetectorWithAnalyticNonGaussianPSF.h
@@ -42,8 +42,6 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
 
         void integrateAnalyticPSF(IntegralOfAnalyticSignalResponse&, double, double, double, double, double, int = 1);
         void makeHighResolutionPSF(arma::Mat<float> &highResMap, bool includeDiffusion, int Npixels, int Nsubpixels);
-        void generateDiffusionKernel(double kernelWidth);
-        void applyDiffusionKernelOnPSF(double subpixRow, double subpixColumn, double flux, arma::fmat& psf, int numberOfPsfSubpixelsPerPixel);
         void flushOutput() override;
 
         // Photometry
@@ -70,10 +68,6 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
         bool writeFlatfieldMap;             // Whether or not to write the flatfield map to the HDF5 file
         bool writeHighResolutionPSF;        // Wheter or not to write the high resosultion PSF to the HDF5 file
         bool writeDiffusedPSF;              // Wheter or not to write the high resosultion PSF to the HDF5 file 
-        arma::Mat<float> diffusionKernel;                   // Diffusion kernel image
-        IntegralOfAnalyticSignalResponse signalResponse;    // Signal response
-        double diffusionKernelWidth;                        // Width (sigma) of the Gaussian diffusion kernel [sub-pixels]
-        int diffusionKernelImageSize;                       // Size of the diffusion kernel image [sub-pixels]
 
         // Photometry
   

--- a/include/DetectorWithAnalyticNonGaussianPSF.h
+++ b/include/DetectorWithAnalyticNonGaussianPSF.h
@@ -16,6 +16,8 @@
 #include "Detector.h"
 #include "Camera.h"
 #include "Parameter.h"
+#include "PointSpreadFunction.h"
+
 
 
 using namespace std;
@@ -56,18 +58,13 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
 
         Parameter<double> *sigma;           // Width of the analytic PSF, equal to sigma for a Gaussian PSF
         vector<vector<double>> params;      // Table of analytic PSF parameters
-
         arma::Mat<float> flatfieldMap;      // Pixel flatfield map
-
         unsigned int numExposures;          // Number of exposures
         unsigned int beginExposureNr;       // Exposure nr of the first exposure in the time series
         double cycleTime;                   // Image cycle time (exposure + readout before next exposure starts)  [s]
-
         double chargeDiffusionStrength;	    // Strength of the charge diffusion (width of the Gaussian diffusion kernel) [pixels]
         bool includeChargeDiffusion;	    // Whether or not to include charge diffusion
-
         double flatfieldNoiseRMS;           // Peak-to-peak noise amplitude
-
         bool includeFlatfield;              // Whether or not to include flat fielding        
         long flatfieldSeed;                 // Seed dedicated to generate a random flatfield map
         bool writeFlatfieldMap;             // Whether or not to write the flatfield map to the HDF5 file
@@ -90,13 +87,14 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
         // E.g. maskSizeTarget[1234][10] contains the nr of pixels of the mask of target 1234 for exposure 10.
 
         map<unsigned int, vector<unsigned int>> exposureNrOfMaskUpdate;   // Photometric mask is updated once in a while
-        map<unsigned int, vector<unsigned int>> maskSizeTarget;                    // Nr of pixels within the mask for each target
+        map<unsigned int, vector<unsigned int>> maskSizeTarget;           // Nr of pixels within the mask for each target
         map<unsigned int, vector<double>> inputFluxTarget;                // Flux of the target as computed from the (variable) Vmag
         map<unsigned int, vector<double>> estimatedFluxTarget;            // Estimated flux for each target
         map<unsigned int, vector<double>> varFluxTarget;                  //  Variance of the flux for each target
         map<unsigned int, vector<double>> NSRtarget;                      // Noise/Signal ratio of the flux of each target
     
         // The indices of the masks are stored as [starID][exposureNr][index]
+  
         map<unsigned int, map<unsigned int, vector<unsigned int>>> rowIndexOfMaskOfTarget;  // The row indices of all mask pixels, for each target
         map<unsigned int, map<unsigned int, vector<unsigned int>>> colIndexOfMaskOfTarget;  // The column indices of all mask pixels, for each target
 

--- a/include/DetectorWithAnalyticNonGaussianPSF.h
+++ b/include/DetectorWithAnalyticNonGaussianPSF.h
@@ -42,6 +42,8 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
         void integrateAnalyticPSF(IntegralOfAnalyticSignalResponse&, double, double, double, double, double, int = 1);
 
         void makeHighResolutionPSF(arma::Mat<float> &highResMap, int Npixels, int Nsubpixels);
+        void generateDiffusionKernel(double kernelWidth);
+        void applyDiffusionKernelOnPSF(double subpixRow, double subpixColumn, double flux, arma::fmat& psf, int numberOfPsfSubpixelsPerPixel);
         virtual void flushOutput() override;
 
         void applyPhotometry(const unsigned int exposureNr);
@@ -57,20 +59,28 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
 
         arma::Mat<float> flatfieldMap;      // Pixel flatfield map
 
-        unsigned int numExposures;                  // Number of exposures
+        unsigned int numExposures;          // Number of exposures
         unsigned int beginExposureNr;       // Exposure nr of the first exposure in the time series
         double cycleTime;                   // Image cycle time (exposure + readout before next exposure starts)  [s]
 
-        double chargeDiffusionStrength;		// Strength of the charge diffusion (width of the Gaussian diffusion kernel) [pixels]
-        bool includeChargeDiffusion;		// Whether or not to include charge diffusion
+        double chargeDiffusionStrength;	    // Strength of the charge diffusion (width of the Gaussian diffusion kernel) [pixels]
+        bool includeChargeDiffusion;	    // Whether or not to include charge diffusion
 
         double flatfieldNoiseRMS;           // Peak-to-peak noise amplitude
 
         bool includeFlatfield;              // Whether or not to include flat fielding        
         long flatfieldSeed;                 // Seed dedicated to generate a random flatfield map
         bool writeFlatfieldMap;             // Whether or not to write the flatfield map to the HDF5 file
-        bool writeHighResolutionPSF;        // Wheter or not to write the high resosultion PSF to the HDF5 file 
+        bool writeHighResolutionPSF;        // Wheter or not to write the high resosultion PSF to the HDF5 file
+        bool writeDiffusedPSF;              // Wheter or not to write the high resosultion PSF to the HDF5 file 
+        arma::Mat<float> diffusionKernel;                   // Diffusion kernel image
+        IntegralOfAnalyticSignalResponse signalResponse;    // Signal response
+        double diffusionKernelWidth;                        // Width (sigma) of the Gaussian diffusion kernel [sub-pixels]
+        int diffusionKernelImageSize;                       // Size of the diffusion kernel image [sub-pixels]
+        PointSpreadFunction *psf;
 
+        // Photometry
+  
         bool includePhotometry;             // Whether or not to include on-the-fly photometry
         int contaminationRadius;            // Stars outside the radius are never considered a contaminant of the main target [pix] 
         double maskUpdateInterval;          // All photometric masks will be updated every xx days  [days]

--- a/include/DetectorWithMappedPSF.h
+++ b/include/DetectorWithMappedPSF.h
@@ -36,49 +36,41 @@ class DetectorWithMappedPSF : public Detector
         void applyInverseDistortion(double &x, double &y) override;
 
     protected:
+  
         bool areColinear(std::array<std::array<double, 2>, 3>);
         void reset() override;
         void initHDF5Groups() override;
         void integrateLight(int exposureNr, double startTime, double exposureTime) override;
-
         bool isInSubPixelMap(double row, double column);
-
-        void applyFlatfield() override;
-
-        
+        void applyFlatfield() override;        
         void applyDiffusionKernel(double row, double column, double flux);
         void generateFlatfieldMap();
         void generateDiffusionKernel(double kernelWidth);
         void rebin();
         void writeSubPixelMapToHDF5(int exposureNr);
-
         void setPsfForSubfield();
-
         void convolveWithPsf();
-
 
         arma::Mat<float> subPixelMap;           // Sub-pixel map, incl. edge pixels
         arma::Mat<float> psfMap;                // The PSF map that will be used for convolving
         arma::Mat<float> flatfieldMap;          // Intra-pixel flatfield map
         vector<std::array<double, 4>> distortionMap;
 
-        double chargeDiffusionStrength;			// Strength of the charge diffusion (width of the Gaussian diffusion kernel) [pixels]
-        bool includeChargeDiffusion;			// Whether or not to include charge diffusion
+        double chargeDiffusionStrength;		// Strength of the charge diffusion (width of the Gaussian diffusion kernel) [pixels]
+        bool includeChargeDiffusion;		// Whether or not to include charge diffusion
         bool includeJitterSmoothing;            // Whether or not to include jitter smoothing
-
         double flatfieldNoiseRMS;               // Peak-to-peak noise amplitude
-
         bool includeFlatfield;                  // Whether or not to include flat fielding
         bool writeFlatfieldMap;                 // Whether or not to write the flatfield map to the HDF5 file
         bool writeSubPixelImagesToHDF5;         // Write subpixel maps to HDF5 as well
         bool includeConvolution;                // Whether or not to convolve the subPixelMap with the PSF
-
         bool writeDiffusedPSF;                  // Whether or not to write the diffused PSF to the output HDF5 file
 
-        arma::Mat<float> diffusionKernel;                    // Diffusion kernel image
+        arma::Mat<float> diffusionKernel;                   // Diffusion kernel image
         IntegralOfAnalyticSignalResponse signalResponse;    // Signal response
         double diffusionKernelWidth;                        // Width (sigma) of the Gaussian diffusion kernel [sub-pixels]
-        int diffusionKernelImageSize;                           // Size of the diffusion kernel image [sub-pixels]
+        int diffusionKernelImageSize;                       // Size of the diffusion kernel image [sub-pixels]
+  
         unsigned int numRowsSubPixelMap;        // Nr of subpixel rows in the subfield incl. edge pixels (= size in the y-direction) [subpixels]
         unsigned int numColumnsSubPixelMap;     // Nr of subpixel columns in the subfield incl. edge pixels (= size in the x-direction = readout direction) [subpixels]
         unsigned int numSubPixelsPerPixel;      // Nr of sub-pixels per pixel

--- a/python/platosim/referenceFrames.py
+++ b/python/platosim/referenceFrames.py
@@ -1773,7 +1773,7 @@ def getPointingRepeatabilityError(ra, dec, kappa, sigma=3, quarter=[1, 8], outdi
         coor[i,:] = np.append(quarters[i], data)
 
     # Save file with relative pointing errors [deg]
-    if outdir it not None:
+    if outdir is not None:
         np.savetxt(f'{outdir}/PRE.txt', coor, fmt=['%i', '%0.8f', '%0.8f', '%0.8f'])
 
     # Print generated values

--- a/python/platosim/simfile.py
+++ b/python/platosim/simfile.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
 from matplotlib.colors import Normalize, LogNorm
-from matplotlib.ticker import FixedLocator, FixedFormatter
+import matplotlib.ticker as ticker
 import matplotlib.patches as patches
 import ipywidgets as widgets
 from astropy.io import fits
@@ -886,10 +886,8 @@ class SimFile (object):
             norm = Normalize(img_min, img_max)
             
         elif imgScale == 'log':
-            image = ut.imageNorm(image, "log", sigma=0.5)
             vmin, vmax = image.min(), image.max()
-            norm  = Normalize(vmin, vmax)
-            #norm   = LogNorm(image.min(), image.max())
+            norm   = LogNorm(vmin, vmax)
 
         elif imgScale == "auto":
             image = ut.imageNorm(image, "linear", sigma=0.5)
@@ -897,7 +895,7 @@ class SimFile (object):
             norm  = Normalize(vmin, vmax)
 
         else:
-            print("Not valid scaling for imgScale!"); exit()
+            ut.errorcode("error", "Not valid scaling for imgScale!")
 
         # Generate image
 
@@ -915,17 +913,21 @@ class SimFile (object):
             cbar = fig.colorbar(imagePlot, extend='max', shrink=0.84, pad=0.015)
             cbar.set_label(clabel, fontsize=fontSize, labelpad=3)
             cbar.ax.tick_params(labelsize=fontSize)
-            
-            if not imgScale == "linear" and not imgScale == "clip":
+
+            # Remove default (small) minor tick label for logarithm plot
+            if imgScale == "log":
+                cbar.ax.tick_params(which='minor', right=False, labelright=False)
+
+            # Adjust the colorbar to correct ADU calues 
+            if not imgScale == "clip":
                 ticks_loc1  = np.linspace(vmin, vmax, 6)
                 ticks_loc2  = np.linspace(img_min, img_max, 6)
                 ticks_label = [f"{i:.1f}" for i in ticks_loc2]
-                print(img_min, img_max)
-                print(vmin, vmax)
-                cbar.locator     = FixedLocator(ticks_loc1)
-                cbar.formatter   = FixedFormatter(ticks_label)
+                cbar.locator     = ticker.FixedLocator(ticks_loc1)
+                cbar.formatter   = ticker.FixedFormatter(ticks_label)
                 cbar.update_ticks()
-
+                
+                
         # If requiered, overplot a gray semi-transparent grid
         # Note: this is only meaningsful for smaller imagettes
 

--- a/source/DetectorWithAnalyticGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticGaussianPSF.cpp
@@ -105,7 +105,7 @@ DetectorWithAnalyticGaussianPSF::~DetectorWithAnalyticGaussianPSF()
 
 
  /**
- * \brief: Generate the (random) flatfield variations.  This map is generated
+ * \brief: Generate the (random) flatfield variations. This map is generated
  *         at pixel level but without the edge pixels.
  *
  * https://github.com/python-acoustics/python-acoustics/blob/master/acoustics/generator.py#L108
@@ -236,20 +236,18 @@ double DetectorWithAnalyticGaussianPSF::takeExposure(int exposureNr, double star
     // Note: readOut() needs the exposure time to compute the open shutter smearing.
 
     Log.info("Detector: Adding noise effects to exposure " + to_string(exposureNr));
-
     readOut(exposureTime);
 
     // Write the CCD subfield, the bias map, and the smearing map to the HDF5 file
 
     Log.debug("Detector: Writing PixelMap, smearing map, and bias map #" + to_string(exposureNr) + " to HDF5 file.");
-
     writePixelMapsToHDF5(exposureNr);
 
     // Write the cosmic hits to the HDF5 file
 
     Log.debug("Detector: Writing Cosmics of the PixelMap, smearing map, bias map #" + to_string(exposureNr) + " to HDF5 file.");
-
     writeCosmicHitsToHDF5(exposureNr);
+    
     // Advance the internal clock
 
     internalTime += exposureTime + readoutTimeBeforeNextExposure;
@@ -326,8 +324,6 @@ void DetectorWithAnalyticGaussianPSF::integrateLight(int exposureNr, double star
         Log.debug("Detector: no flatfield applied.");
     }
 
-
-
     // Apply the effects of readout smearing due to an open shutter. Because there is no shutter,
     // the pixels are still receiving photons from the sky, while they are being transfered towards
     // the readout register.
@@ -358,8 +354,6 @@ void DetectorWithAnalyticGaussianPSF::integrateLight(int exposureNr, double star
         Log.debug("Detector: no photon noise added.");
     }
 
-
-    
     // Add dark current
 
     if(includeDarkSignal)
@@ -371,10 +365,7 @@ void DetectorWithAnalyticGaussianPSF::integrateLight(int exposureNr, double star
     else
     {
         Log.debug("Detector: no dark current added");
-    }
-
-
-    
+    }    
 }
 
 
@@ -510,6 +501,7 @@ tuple<bool, double, double> DetectorWithAnalyticGaussianPSF::addFlux(double xFP,
  * \return: Whether or not the extended source falls (at least partially) on the sub-field, and the
  *          (row, column) coordinates of the centre of the extended ghost in the pixel map.
  */
+
 tuple<bool, double, double> DetectorWithAnalyticGaussianPSF::addExtendedGhost(double x0, double y0, double radius, double flux)
 {
     // Calculate the number of pixels in the extended ghost
@@ -569,7 +561,6 @@ void DetectorWithAnalyticGaussianPSF::addFlux(double flux)
                       numRowsPixelMap - coveredTop - 1,
                       numColumnsPixelMap - coveredRight - 1) += flux;
     }
-
 }
 
 

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -41,10 +41,15 @@ DetectorWithAnalyticNonGaussianPSF::DetectorWithAnalyticNonGaussianPSF(Configura
 
     if(includeFlatfield)
     {
-    		// Generate the flatfield map
-
-    		generateFlatfieldMap();
+      // Generate the flatfield map
+      
+      generateFlatfieldMap();
     }
+
+    // Initialize and load the PSF. This will open the PSF HDF5 file and perform some basic checking,
+    // Then select the proper PSF for the given subfield. Should only be done after calling configure().
+
+    psf = new PointSpreadFunction(configParam, hdf5file);
 }
 
 
@@ -904,7 +909,6 @@ void DetectorWithAnalyticNonGaussianPSF::generateDiffusionKernel(double kernelWi
 
 void DetectorWithAnalyticNonGaussianPSF::writeDiffusedPSFToHDF5(PointSpreadFunction *psf)
 {
-
     // make hard copy of original PSF
   
     arma::fmat psfMap = psf->getOriginalPSF();

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -194,6 +194,7 @@ void DetectorWithAnalyticNonGaussianPSF::configure(ConfigurationParameters &conf
     
     writeFlatfieldMap = configParam.getBoolean("ControlHDF5Content/WriteFlatfieldMap");
     writeHighResolutionPSF = configParam.getBoolean("ControlHDF5Content/WriteHighResolutionPSF");
+    writeDiffusedPSF = configParam.getBoolean("ControlHDF5Content/WriteDiffusedPSF");
 
 } // end configure()
 
@@ -777,7 +778,6 @@ void DetectorWithAnalyticNonGaussianPSF::makeHighResolutionPSF(arma::Mat<float> 
     double xFP, yFP;
     tie(xFP, yFP) = pixelToFocalPlaneCoordinates(middleRowSubfield, middleColSubfield);
 
-
     double s = (*sigma)();
     double diffusionKernelWidth = 0.;
 
@@ -881,6 +881,116 @@ void DetectorWithAnalyticNonGaussianPSF::applyFlatfield()
 
 
 
+//************************** Diffused PSF *****************************//
+
+/**
+  * \brief: Generate the diffusion kernel. This is generated at sub-pixel level.
+  *
+  * \param kernelWidth: Width (sigma) of the Gaussian diffusion kernel [sub-pixels].
+  */
+void DetectorWithAnalyticNonGaussianPSF::generateDiffusionKernel(double kernelWidth)
+{
+    diffusionKernelWidth = kernelWidth;
+    diffusionKernelImageSize = 2 * (int)(8 * kernelWidth + 1) + 1;
+
+    diffusionKernel.zeros(diffusionKernelImageSize, diffusionKernelImageSize);
+}
+
+
+
+/**
+ * \brief: Write the diffused and rotated PSF to the HDF5 file.
+ */
+
+void DetectorWithAnalyticNonGaussianPSF::writeDiffusedPSFToHDF5(PointSpreadFunction *psf)
+{
+
+    // make hard copy of original PSF
+  
+    arma::fmat psfMap = psf->getOriginalPSF();
+    arma::fmat diffusedPsf = arma::fmat(size(psfMap), arma::fill::zeros);
+
+    int numRows = size(psfMap)(0);
+    int numColumns = size(psfMap)(1);
+
+    // set the diffusion kernel image size
+    
+    int psfSubPixelsPerPixel = psf->getNumSubPixelsPerPixel();
+    generateDiffusionKernel(chargeDiffusionStrength*psfSubPixelsPerPixel);
+
+    for (int row=0; row < numRows; row++)
+    {
+      for (int column=0; column < numColumns; column++)
+      {
+	applyDiffusionKernelOnPSF(row, column, psfMap(row, column), diffusedPsf, psfSubPixelsPerPixel);
+      }
+    }
+
+    // reset the diffusion kernel
+    
+    generateDiffusionKernel(chargeDiffusionStrength*numSubPixelsPerPixel);
+
+    // rotate the diffused PSF
+    
+    diffusedPsf = ArrayOperations::rotateArray(diffusedPsf, -rotationAnglePsf);
+
+    // Normalize the PSF
+
+    diffusedPsf /= arma::accu(diffusedPsf);
+
+    // write the diffused psf to the output hdf5 file
+    
+    hdf5File.writeArray("/PSF", "diffusedPSF", diffusedPsf);
+}
+
+
+
+/**
+ * \brief: Apply the diffused kernel on the PSF.
+ */
+
+void DetectorWithAnalyticNonGaussianPSF::applyDiffusionKernelOnPSF(double subpixRow, double subpixColumn, double flux, arma::fmat& psf, int numberOfPsfSubpixelsPerPixel)
+{
+    int sx = subpixColumn - (diffusionKernelImageSize - 1) / 2;
+    int sy = subpixRow - (diffusionKernelImageSize - 1) / 2;
+
+    double ox = subpixColumn - floor(subpixColumn);
+    double oy = subpixRow - floor(subpixRow);
+
+    int numRows = size(psf)(0);
+    int numColumns = size(psf)(1);
+
+    // Establish diffusion kernel image
+
+    signalResponse = IntegralOfAnalyticSignalResponse(diffusionKernelImageSize);
+    signalResponse.addPart(ox, oy, 1., diffusionKernelWidth);
+
+    for (unsigned int row = 0; row < diffusionKernelImageSize; row++)
+    {
+        for (unsigned int column = 0; column < diffusionKernelImageSize; column++)
+        {
+            diffusionKernel(row, column) = signalResponse(column, row); // Normalisation done by ()-operator
+        }
+    }
+
+    // Add the flux to the psf
+
+    arma::span rowSpan = arma::span(max(0, sy), min((int)numRows, sy + diffusionKernelImageSize) - 1);
+    arma::span columnSpan = arma::span(max(0, sx), min((int)numColumns, sx + diffusionKernelImageSize) - 1);
+
+    arma::span xSpan = arma::span(max(0, sx) - sx, min((int)numColumns, sx + diffusionKernelImageSize) - sx - 1);
+    arma::span ySpan = arma::span(max(0, sy) - sy, min((int)numRows, sy + diffusionKernelImageSize) - sy - 1);
+
+    psf(rowSpan, columnSpan) += diffusionKernel(ySpan, xSpan) * flux;
+}
+
+//**************************************************************//
+
+
+
+
+
+
 
 /**
  *  \brief Before destroying this object, save all info to the HDF5 file
@@ -892,21 +1002,35 @@ void DetectorWithAnalyticNonGaussianPSF::flushOutput()
     int Npixels = 8;
     int Nsubpixels = 128;
 
-    // Create the group in the HDF5 file. We chose the same name as for DetectorWithMappedPSF
+    // Create the group in the HDF5 file.
+    // We chose the same name as for DetectorWithMappedPSF
 
     hdf5File.createGroup("/PSF");
     
-    // Generate the high-resolution map
+    // Generate and save the high resolution PSF (center of subfield)
 
     arma::Mat<float> highResMap;
     makeHighResolutionPSF(highResMap, Npixels, Nsubpixels);
 
-    // Save the map to HDF5
     if (writeHighResolutionPSF)
     {
-    hdf5File.writeArray("/PSF", "HighResPSFmapCenterSubfield", highResMap);
+      Log.info("Writing high resolution PSF to the HDF5 file");
+   
+      hdf5File.writeArray("/PSF", "highResPSF", highResMap);
     }
 
+    // Generate and save the diffused PSF (center of subfield)
+    
+    if (writeDiffusedPSF)
+    {
+      Log.info("Writing diffused PSF to the HDF5 file");
+      
+      arma::Mat<float> diffusedMap;
+      makeDiffusedPSF(diffusedMap, Npixels, Nsubpixels);
+
+      hdf5File.writeArray("/PSF", "diffusedPSF", diffusedMap);
+    }
+    
     // Save the photometry info
 
     if (includePhotometry)

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -48,8 +48,6 @@ DetectorWithAnalyticNonGaussianPSF::DetectorWithAnalyticNonGaussianPSF(Configura
 
     // Initialize and load the PSF. This will open the PSF HDF5 file and perform some basic checking,
     // Then select the proper PSF for the given subfield. Should only be done after calling configure().
-
-    psf = new PointSpreadFunction(configParam, hdf5file);
 }
 
 
@@ -767,7 +765,7 @@ tuple<bool, double, double> DetectorWithAnalyticNonGaussianPSF::addExtendedGhost
  *                   Its size will be  (Npixels * Nsubpixels) x  (Npixels * Nsubpixels)
  */
 
-void DetectorWithAnalyticNonGaussianPSF::makeHighResolutionPSF(arma::Mat<float> &highResMap, int Npixels, int Nsubpixels)
+void DetectorWithAnalyticNonGaussianPSF::makeHighResolutionPSF(arma::Mat<float> &highResMap, bool includeDiffusion, int Npixels, int Nsubpixels)
 {
     // Put the PSF right in the middle of the (high-res) (sub)pixel map
 
@@ -783,21 +781,23 @@ void DetectorWithAnalyticNonGaussianPSF::makeHighResolutionPSF(arma::Mat<float> 
     double xFP, yFP;
     tie(xFP, yFP) = pixelToFocalPlaneCoordinates(middleRowSubfield, middleColSubfield);
 
-    double s = (*sigma)();
+    // Convolve with Gaussian diffusion kernel is requested
+    
+    //double s = (*sigma)();
     double diffusionKernelWidth = 0.;
 
-    if (includeChargeDiffusion) 
+    if (includeDiffusion)
     {
         diffusionKernelWidth = chargeDiffusionStrength;
-        s = sqrt(s * s + diffusionKernelWidth * diffusionKernelWidth);
+        //s = sqrt(s * s + diffusionKernelWidth * diffusionKernelWidth);
     }
 
     int size = Npixels * Nsubpixels;
     highResMap.set_size(size, size);
     highResMap.fill(0.0);
 
-    int sx = (int)floor(column0*Nsubpixels - (size - 1.) / 2.);
-    int sy = (int)floor(row0*Nsubpixels - (size - 1.) / 2.);
+    int sx = (int)floor(column0 * Nsubpixels - (size - 1.) / 2.);
+    int sy = (int)floor(row0    * Nsubpixels - (size - 1.) / 2.);
 
     // Construct the PSF around the central pixel coordinates
 
@@ -886,115 +886,6 @@ void DetectorWithAnalyticNonGaussianPSF::applyFlatfield()
 
 
 
-//************************** Diffused PSF *****************************//
-
-/**
-  * \brief: Generate the diffusion kernel. This is generated at sub-pixel level.
-  *
-  * \param kernelWidth: Width (sigma) of the Gaussian diffusion kernel [sub-pixels].
-  */
-void DetectorWithAnalyticNonGaussianPSF::generateDiffusionKernel(double kernelWidth)
-{
-    diffusionKernelWidth = kernelWidth;
-    diffusionKernelImageSize = 2 * (int)(8 * kernelWidth + 1) + 1;
-
-    diffusionKernel.zeros(diffusionKernelImageSize, diffusionKernelImageSize);
-}
-
-
-
-/**
- * \brief: Write the diffused and rotated PSF to the HDF5 file.
- */
-
-void DetectorWithAnalyticNonGaussianPSF::writeDiffusedPSFToHDF5(PointSpreadFunction *psf)
-{
-    // make hard copy of original PSF
-  
-    arma::fmat psfMap = psf->getOriginalPSF();
-    arma::fmat diffusedPsf = arma::fmat(size(psfMap), arma::fill::zeros);
-
-    int numRows = size(psfMap)(0);
-    int numColumns = size(psfMap)(1);
-
-    // set the diffusion kernel image size
-    
-    int psfSubPixelsPerPixel = psf->getNumSubPixelsPerPixel();
-    generateDiffusionKernel(chargeDiffusionStrength*psfSubPixelsPerPixel);
-
-    for (int row=0; row < numRows; row++)
-    {
-      for (int column=0; column < numColumns; column++)
-      {
-	applyDiffusionKernelOnPSF(row, column, psfMap(row, column), diffusedPsf, psfSubPixelsPerPixel);
-      }
-    }
-
-    // reset the diffusion kernel
-    
-    generateDiffusionKernel(chargeDiffusionStrength*numSubPixelsPerPixel);
-
-    // rotate the diffused PSF
-    
-    diffusedPsf = ArrayOperations::rotateArray(diffusedPsf, -rotationAnglePsf);
-
-    // Normalize the PSF
-
-    diffusedPsf /= arma::accu(diffusedPsf);
-
-    // write the diffused psf to the output hdf5 file
-    
-    hdf5File.writeArray("/PSF", "diffusedPSF", diffusedPsf);
-}
-
-
-
-/**
- * \brief: Apply the diffused kernel on the PSF.
- */
-
-void DetectorWithAnalyticNonGaussianPSF::applyDiffusionKernelOnPSF(double subpixRow, double subpixColumn, double flux, arma::fmat& psf, int numberOfPsfSubpixelsPerPixel)
-{
-    int sx = subpixColumn - (diffusionKernelImageSize - 1) / 2;
-    int sy = subpixRow - (diffusionKernelImageSize - 1) / 2;
-
-    double ox = subpixColumn - floor(subpixColumn);
-    double oy = subpixRow - floor(subpixRow);
-
-    int numRows = size(psf)(0);
-    int numColumns = size(psf)(1);
-
-    // Establish diffusion kernel image
-
-    signalResponse = IntegralOfAnalyticSignalResponse(diffusionKernelImageSize);
-    signalResponse.addPart(ox, oy, 1., diffusionKernelWidth);
-
-    for (unsigned int row = 0; row < diffusionKernelImageSize; row++)
-    {
-        for (unsigned int column = 0; column < diffusionKernelImageSize; column++)
-        {
-            diffusionKernel(row, column) = signalResponse(column, row); // Normalisation done by ()-operator
-        }
-    }
-
-    // Add the flux to the psf
-
-    arma::span rowSpan = arma::span(max(0, sy), min((int)numRows, sy + diffusionKernelImageSize) - 1);
-    arma::span columnSpan = arma::span(max(0, sx), min((int)numColumns, sx + diffusionKernelImageSize) - 1);
-
-    arma::span xSpan = arma::span(max(0, sx) - sx, min((int)numColumns, sx + diffusionKernelImageSize) - sx - 1);
-    arma::span ySpan = arma::span(max(0, sy) - sy, min((int)numRows, sy + diffusionKernelImageSize) - sy - 1);
-
-    psf(rowSpan, columnSpan) += diffusionKernel(ySpan, xSpan) * flux;
-}
-
-//**************************************************************//
-
-
-
-
-
-
 
 /**
  *  \brief Before destroying this object, save all info to the HDF5 file
@@ -1012,27 +903,25 @@ void DetectorWithAnalyticNonGaussianPSF::flushOutput()
     hdf5File.createGroup("/PSF");
     
     // Generate and save the high resolution PSF (center of subfield)
-
-    arma::Mat<float> highResMap;
-    makeHighResolutionPSF(highResMap, Npixels, Nsubpixels);
-
+    
     if (writeHighResolutionPSF)
     {
       Log.info("Writing high resolution PSF to the HDF5 file");
-   
+
+      arma::Mat<float> highResMap;
+      makeHighResolutionPSF(highResMap, false, Npixels, Nsubpixels);
       hdf5File.writeArray("/PSF", "highResPSF", highResMap);
     }
 
     // Generate and save the diffused PSF (center of subfield)
     
-    if (writeDiffusedPSF)
+    if (writeDiffusedPSF && includeChargeDiffusion)
     {
-      Log.info("Writing diffused PSF to the HDF5 file");
-      
-      arma::Mat<float> diffusedMap;
-      makeDiffusedPSF(diffusedMap, Npixels, Nsubpixels);
+      Log.info("Writing diffused high resolution PSF to the HDF5 file");
 
-      hdf5File.writeArray("/PSF", "diffusedPSF", diffusedMap);
+      arma::Mat<float> highResDiffusedMap;
+      makeHighResolutionPSF(highResDiffusedMap, true, Npixels, Nsubpixels);
+      hdf5File.writeArray("/PSF", "diffusedPSF", highResDiffusedMap);
     }
     
     // Save the photometry info

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -130,7 +130,7 @@ void DetectorWithMappedPSF::configure(ConfigurationParameters &configParam)
 
 
 /**
- * \brief Set the PSF map for the sub-field and sets  the distortion map
+ * \brief Set the PSF map for the sub-field and sets the distortion map
  *
  * \details The PSF that is selected is dependent on the user input.
  */
@@ -479,7 +479,6 @@ void DetectorWithMappedPSF::integrateLight(int exposureNr, double startTime, dou
     // Rebin from a subpixel map to a pixel map
 
     Log.debug("DetectorWithMappedPSF: rebinning sub-pixel map into pixel map.");
-
     rebin();
 
     // Apply throughput efficiency on the pixel map
@@ -500,14 +499,11 @@ void DetectorWithMappedPSF::integrateLight(int exposureNr, double startTime, dou
         applyChargeInjection();
     }
 
-
-
     // Apply the effects of readout smearing due to an open shutter. Because there is no shutter,
     // the pixels are still receiving photons from the sky, while they are being transfered towards
     // the readout register.
     // Pixel units before: [electrons]
     // Pixel units after: [electrons]
-
 
     if (includeOpenShutterSmearing)
     {
@@ -523,7 +519,6 @@ void DetectorWithMappedPSF::integrateLight(int exposureNr, double startTime, dou
     // Pixel units before: [electrons]
     // Pixel units after: [electrons]
 
-
     if (includePhotonNoise)
     {
         Log.debug("Detector: adding photon noise.");
@@ -533,7 +528,6 @@ void DetectorWithMappedPSF::integrateLight(int exposureNr, double startTime, dou
     {
         Log.debug("Detector: no photon noise added.");
     }
-
 
     // Add dark current
 
@@ -772,6 +766,10 @@ bool DetectorWithMappedPSF::isInSubPixelMap(double row, double column)
 
 }
 
+
+
+
+
 /**
  * \brief: Add the given flux value to (all sub-pixels that are not covered by a metallic
  *         shield of) the sub-pixel map.
@@ -795,8 +793,6 @@ void DetectorWithMappedPSF::addFlux(double flux)
           flux / numSubPixelsPerPixel / numSubPixelsPerPixel;
     }
 }
-
-
 
 
 
@@ -906,7 +902,7 @@ void DetectorWithMappedPSF::convolveWithPsf()
 
 /**
  * \brief: Creates the group(s) in the HDF5 file where the detector specific
- *         information will be stored.  These groups have to be created once,
+ *         information will be stored. These groups have to be created once,
  *         at the very beginning.
  */
 void DetectorWithMappedPSF::initHDF5Groups()
@@ -960,6 +956,7 @@ void DetectorWithMappedPSF::writeDiffusedPSFToHDF5(PointSpreadFunction *psf)
     int numColumns = size(psfMap)(1);
 
     // set the diffusion kernel image size
+    
     int psfSubPixelsPerPixel = psf->getNumSubPixelsPerPixel();
     generateDiffusionKernel(chargeDiffusionStrength*psfSubPixelsPerPixel);
 
@@ -972,14 +969,19 @@ void DetectorWithMappedPSF::writeDiffusedPSFToHDF5(PointSpreadFunction *psf)
     }
 
     // reset the diffusion kernel
+    
     generateDiffusionKernel(chargeDiffusionStrength*numSubPixelsPerPixel);
 
-
     // rotate the diffused PSF
+    
     diffusedPsf = ArrayOperations::rotateArray(diffusedPsf, -rotationAnglePsf);
+
+    // normalize the PSF
+    
     diffusedPsf /= arma::accu(diffusedPsf);
 
     // write the diffused psf to the output hdf5 file
+    
     hdf5File.writeArray("/PSF", "diffusedPSF", diffusedPsf);
 }
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -153,6 +153,7 @@ void DetectorWithMappedPSF::setPsfForSubfield()
     }
 
     // If requestied save the diffused PSF to the output file
+    
     if (writeDiffusedPSF)
     {
       writeDiffusedPSFToHDF5(psf);
@@ -1028,6 +1029,10 @@ void DetectorWithMappedPSF::applyDiffusionKernelOnPSF(double subpixRow, double s
 }
 
 
+
+
+
+
 /*
  * /brief: determins if three points in (given in an array) are colinear
  * /input: an array with the points of the form {{x1, y1}, {x2, y2}, {x3, y3}}
@@ -1037,6 +1042,7 @@ void DetectorWithMappedPSF::applyDiffusionKernelOnPSF(double subpixRow, double s
  * |x1 x2 x3| is equal to zero.
  * |y1 y2 y3|
  */
+
 bool DetectorWithMappedPSF::areColinear(std::array<std::array<double, 2>, 3> points)
 {
     double determinant = points[1][0] * points[2][1] - points[2][0] * points[1][1] - points[0][0] * points[2][1] + points[2][0] * points[0][1] + points[0][0] * points[1][1] - points[1][0] * points[0][1];
@@ -1053,10 +1059,13 @@ bool DetectorWithMappedPSF::areColinear(std::array<std::array<double, 2>, 3> poi
 
 
 
+
+
 /*
  * /brief: applies the field distortion on the inputparameters from the distortion map
  * /input: FP coordinates [mm]
  */
+
 void DetectorWithMappedPSF::applyDistortion(double &x, double &y)
 {
   // We try to sellect the three closest noncolinear undistorted points to our input coordinates from the distortionmap and their respective
@@ -1190,12 +1199,19 @@ void DetectorWithMappedPSF::applyDistortion(double &x, double &y)
 }
 
 
+
+
+
+
+
 /*
  * /brief: applies the inverse of the field distortion on the input coordinates
  * /input: FP coordinates [mm]
  */
+
 void DetectorWithMappedPSF::applyInverseDistortion(double &x, double &y)
 {
+
   // We try to sellect the three closest noncolinear distorted points to our input coordinates from the distortionmap and their respective
   // undistorted counterparts
 


### PR DESCRIPTION
A new feature has been implemented so it is now possible to save high resolution (non-diffused and diffused) PSFs to the HDF5 file when using an analytic non-Gaussian model. Before this was only possible when using mapped PSF.s  