### PR TITLE
Bugfix - fixing picsim crashing by passing star magnitudes as a keyword argument

### DIFF
--- a/python/platosim/picsim/picsim
+++ b/python/platosim/picsim/picsim
@@ -649,7 +649,7 @@ if platoField is None:
 if len(df['ID']) > 200: plotmag = None
 else: plotmag = df['mag'].to_numpy()
 title = f'{platoField} {starSample} sample'
-fig1 = pt.plotPlatoFOV(platoField, df['ra'].to_numpy(), df['dec'].to_numpy(), plotmag, title=title)
+fig1 = pt.plotPlatoFOV(platoField, df['ra'].to_numpy(), df['dec'].to_numpy(), magStars=plotmag, title=title)
 if plot: plt.show()
 
 # Plot sample distribution in Teff vs. Radius


### PR DESCRIPTION
Currently, picsim crashes on the second plot at line 652 because the plot magnitudes are passed at the position where the function expects the "system" argument.

I fixed this by passing the plot magnitudes as a keyword argument explicitly.