### PR TITLE
Big fix in throughput map

### DIFF
--- a/include/Detector.h
+++ b/include/Detector.h
@@ -294,6 +294,7 @@ class Detector: public HDF5Writer
 
         bool includeBFE;                         // Whether or not to include the BFE
         bool includeDarkSignal;                  // Whether or not to include dark
+        bool includeFieldDistortion;             // Whether or not to include field distortion
         bool includePhotonNoise;                 // Whether or not to include photon noise
         bool includeReadoutNoise;                // Include readout noise [yes or no]
         bool includeCTIeffects;                  // Include CTI effects [yes or no]

--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -489,6 +489,7 @@ void Detector::updateParameters(double time)
     includeFullWellSaturation       = configParam.getBoolean("CCD/IncludeFullWellSaturation");
     includeDigitalSaturation        = configParam.getBoolean("CCD/IncludeDigitalSaturation");
     includeQuantisation             = configParam.getBoolean("CCD/IncludeQuantisation");
+    includeFieldDistortion          = configParam.getBoolean("Camera/IncludeFieldDistortion");
 
     if(includeRelativeTransmissivity)
     {
@@ -861,8 +862,15 @@ void Detector::generateThroughputMap()
                 tie(xFPmmDistorted, yFPmmDistorted) = pixelToFocalPlaneCoordinates(row + subFieldZeroPointRow, column + subFieldZeroPointColumn);
 
                 // Convert from distorted to undistorted focal plane coordinates (Cf GitHub issue #716)
-
-                tie(xFPmmUndistorted, yFPmmUndistorted) =  camera.distortedToUndistortedFocalPlaneCoordinates(xFPmmDistorted, yFPmmDistorted);
+                if (includeFieldDistortion)
+                {
+                    tie(xFPmmUndistorted, yFPmmUndistorted) =  camera.distortedToUndistortedFocalPlaneCoordinates(xFPmmDistorted, yFPmmDistorted);
+                }
+                else
+                {
+                    xFPmmUndistorted = xFPmmDistorted;
+                    yFPmmUndistorted = yFPmmDistorted;
+                }
 
                 // Angular distance [radians] of the pixel from the optical axis
 


### PR DESCRIPTION
When generating the throughputmap we only convert coordinates from distortorted to undistorted if distortion is taken into accout. (with analytic PSF)