### PR TITLE
Fixing "fix" of last pull request

### DIFF
--- a/python/platosim/picsim/picsim
+++ b/python/platosim/picsim/picsim
@@ -432,11 +432,11 @@ if fileFormat != '.txt':
     # Check spectral type
     if specType is not None:
         if specType == 'K':
-            df = df_dK if lumClass == 'V' else df_sgK
+            df = df_dK if lumClass == 'V' else (df_sgK if lumClass == 'IV' else pd.concat([df_dK, df_sgK]))
         elif specType == 'G':
-            df = df_dG if lumClass == 'V' else df_sgG
+            df = df_dG if lumClass == 'V' else (df_sgG if lumClass == 'IV' else pd.concat([df_dG, df_sgG]))
         elif specType == 'F':
-            df = df_dF if lumClass == 'V' else df_sgF
+            df = df_dF if lumClass == 'V' else (df_sgF if lumClass == 'IV' else pd.concat([df_dF, df_sgF]))
         else:
             errorcode('error', 'Not valid spectral type for PIC stars!')
 


### PR DESCRIPTION
Hi! Very embarrassingly, I missed out one test case in my fix of the --spec and --lum flag behaviour. Currently, the --spec flag by itself causes only subgiants of that spectral type to be selected. With this fix, `--spec K`, for example now selects a mixture of MS and SG stars when a --lum flag is not provided.

Really sorry for the spam!

Edit: screenshots don't seem to be working, so I removed them, but I tested every possible combination.
