### PR TITLE
Bugfix of simfile.getTime()

### DIFF
--- a/python/platosim/simfile.py
+++ b/python/platosim/simfile.py
@@ -138,13 +138,13 @@ class SimFile (object):
         if ccdCode == "Custom": ccdCode = "1"
         timeShift     = self.getInputParameter("CCDPositions", "TimeShift")[int(ccdCode)-1]
 
-        return np.arange(beginExposure, numExposures) * cadence + timeShift
+        return np.arange(beginExposure, beginExposure + numExposures) * cadence + timeShift
 
         # TODO fix this in future!
         if ccdCode == "Custom": ccdCode = "1"
         timeShift     = self.getInputParameter("CCDPositions", "TimeShift")[int(ccdCode)-1]
 
-        return np.arange(beginExposure, numExposures) * cadence + timeShift
+        return np.arange(beginExposure, beginExposure + numExposures) * cadence + timeShift
 
 
 


### PR DESCRIPTION
It's currently impossible to get time arrays for quarters after Q1 because of a typo in the getTime() function. This fixes the problem.