### PR TITLE
Adaptation of platonium to new quaternions

### DIFF
--- a/python/platosim/picsim/picsim
+++ b/python/platosim/picsim/picsim
@@ -33,6 +33,7 @@ Usage examples:
 
 # Python standard
 import os
+import shutil
 import random
 import warnings
 import argparse
@@ -71,17 +72,19 @@ parser = argparse.ArgumentParser(epilog=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter,
                                  description=errorcode('software', '\nPIC of Destiny'))
 
-parser.add_argument('-p', '--plot', action='store_true', help='Flag to plot target and contaminant catalog creation')
-parser.add_argument('-s', '--save', action='store_true', help='Flag to save target and contaminant catalog into a PlatoSim like starcatalog format')
-parser.add_argument('-t', '--targ', action='store_true', help='Flag to only show catalogue illustration (mainly testing)')
-parser.add_argument('-o', '--outdir', type=str, metavar='STR', help='Output directory to save catalogue and plots')
-parser.add_argument('-i', '--incat',  type=str, nargs='*',     help='PIC input target- and contaminant files (Format: csv, txt, ftr)')
-parser.add_argument('-u', '--unique', type=str, metavar='STR', help='Parse old picsim target catalogue to select new unique stars (Format: ftr)')
-
 pic_group = parser.add_argument_group('PIC INFO (required)')
 pic_group.add_argument('targets', type=str, help='Number of targets saved in catalog (Select "all" for all stars)')
 pic_group.add_argument('sample',  type=str, help='PIC samples [P1, P2, P4, P5, all]  (Select "all" for all samples)')
 pic_group.add_argument('field',   type=str, help='PLATO fields [NPF, SPF, all]       (Select "all" for both fields)')
+
+out_group = parser.add_argument_group('I/O PARAMETERS')
+out_group.add_argument('-p', '--plot', action='store_true', help='Flag to plot target and contaminant catalog creation')
+out_group.add_argument('-s', '--save', action='store_true', help='Flag to save target and contaminant catalog into a PlatoSim like starcatalog format')
+out_group.add_argument('-t', '--targ', action='store_true', help='Flag to only show catalogue illustration (mainly testing)')
+out_group.add_argument('-o', '--outdir', type=str, metavar='STR', help='Output directory to save catalogue and plots')
+out_group.add_argument('--project',     type=str, metavar='NAME', help='Name project folder within $PLATO_WORKDIR')
+out_group.add_argument('-i', '--incat',  type=str, nargs='*',     help='PIC input target- and contaminant files (Format: csv, txt, ftr)')
+out_group.add_argument('-u', '--unique', type=str, metavar='STR', help='Parse old picsim target catalogue to select new unique stars (Format: ftr)')
 
 que_group = parser.add_argument_group('QUERY OPTIONS (optional)')
 que_group.add_argument('--query', type=str, metavar='NAME',   help='Simbad target for query using Gaia DR2')
@@ -89,19 +92,24 @@ que_group.add_argument('--dmag',  type=int, metavar='MAG',    help='Delta magnit
 que_group.add_argument('--dist',  type=int, metavar='ARCSEC', help='Radial distance to fecth contaminants [30, 45, 60] (Default: 45 arcsec)')
 
 obs_group = parser.add_argument_group('OBSERVABLES (optional)')
-obs_group.add_argument('--camera', metavar='NUM',   type=str, help='N-CAM visibility [6, 12, 18, 24]')
-obs_group.add_argument('--group',  metavar='NUM',   type=int, help='Camera-group visibility [1, 2, 3, 4]')
-obs_group.add_argument('--mag',    metavar='RANGE', type=str, help='P magnitude range of PIC targets (float or dash-range)')
-obs_group.add_argument('--spec',   metavar='TYPE',  type=str, help='Spectral type [F, G, K]')
-obs_group.add_argument('--lum',    metavar='CLASS', type=str, help='Luminosity class [V, IV]')
-obs_group.add_argument('--ntime',  metavar='NUM',   type=int, help='Number of individual timeseries to be generated')
+obs_group.add_argument('--ncams', metavar='NUM',   type=str, help='N-CAM visibility [6, 12, 18, 24]')
+obs_group.add_argument('--group', metavar='NUM',   type=int, help='Camera-group visibility [1, 2, 3, 4]')
+obs_group.add_argument('--mag',   metavar='RANGE', type=str, help='P magnitude range of PIC targets (float or dash-range)')
+obs_group.add_argument('--spec',  metavar='TYPE',  type=str, help='Spectral type [F, G, K]')
+obs_group.add_argument('--lum',   metavar='CLASS', type=str, help='Luminosity class [V, IV]')
+obs_group.add_argument('--ntime', metavar='NUM',   type=int, help='Number of individual timeseries to be generated')
 
 args = parser.parse_args()
+
+numTargets    = args.targets
+starSample    = args.sample
+platoField    = args.field
 
 plot          = args.plot
 subfield      = args.save
 onlyTargets   = args.targ
 outputDir     = args.outdir
+project       = args.project
 inputFiles    = args.incat
 oldCatalogue  = args.unique
 
@@ -109,12 +117,8 @@ targetQuery   = args.query
 dmagConLimit  = args.dmag
 disConLimit   = args.dist
 
-numTargets    = args.targets
-starSample    = args.sample
-platoField    = args.field
-ncamVisible   = args.camera
+ncamVisible   = args.ncams
 camGroup      = args.group
-
 magRange      = args.mag
 specType      = args.spec
 lumClass      = args.lum
@@ -159,24 +163,34 @@ inputFileCon = inputDir / 'PIC110contaminant.npy'
 outputPrefix = 'starcat'
 if args.sample: outputPrefix += '_' + args.sample
 if args.field:  outputPrefix += '_' + args.field
-if args.group:  outputPrefix += '_Ncam' + str(args.group)
-if args.camera: outputPrefix += '_CamVis' + args.camera
+if args.group:  outputPrefix += '_Group' + str(args.group)
+if args.ncams:  outputPrefix += '_Ncam' + args.ncams
 if inputFiles is not None: outputPrefix += '_NewCat'
 outputPrefixTar = outputPrefix + '_targets'      + fileFormat
 outputPrefixCon = outputPrefix + '_contaminants' + fileFormat
 
 # Name space for output files
-if outputDir is not None:
+if outputDir is not None or project is not None:
     # Resolve absolute output directory
-    outputDir = Path(outputDir).resolve()
+    if outputDir is not None:
+        outputDir = Path(outputDir).resolve()
+    elif project is not None:
+        outputDir = Path(os.getenv('PLATO_WORKDIR')) / project / 'input'
+    # Set file names
     if subfield:
         outputFileFOV = (outputDir / outputPrefix).joinwith_suffix(fileFormat)
     else:
         outputFileTar = outputDir / outputPrefixTar
         outputFileCon = outputDir / outputPrefixCon
 
+# Copy an inputfile.yaml file if no file exist
+inputFileYAML = Path(os.getenv('PLATO_PROJECT_HOME')) / 'inputfiles/inputfile.yaml'
+inputFileNew  = outputDir / 'inputfile.yaml'
+if not inputFileNew.is_file():
+    shutil.copy(inputFileYAML, inputFileNew)
+        
 
-#--------------------
+#-----------------------------------------------------------------
 # TODO implement properly such dmag and dist can be requested too
 if targetQuery:
     df = starQuery(targetQuery)
@@ -186,7 +200,7 @@ if targetQuery:
     if outputDir is not None:
         df.to_csv(outputDir / f"starcat_{targetQuery}.txt", sep=' ', header=False)    
     exit()
-#--------------------
+#-----------------------------------------------------------------
 
         
 # Select PIC sample
@@ -843,7 +857,7 @@ if outputDir is not None:
         dfc.to_feather(outputFileCon)
 
         # Output file name of HPC data
-        outputVarFileName = f'{outputDir}/data_hpc_{outputPrefix}.txt'
+        outputVarFileName = f'{outputDir}/cluster_{outputPrefix}.txt'
         print(f'Saving file {outputVarFileName}')
         headerVar = 'PIC, M, R, Teff'
         outputVarData = np.transpose([df['ID'].to_numpy(), df['M'].to_numpy(),

--- a/python/platosim/platonium/platonium
+++ b/python/platosim/platonium/platonium
@@ -209,7 +209,7 @@ class PLATOnium(object):
 
         if self.starcatFile is not None:
             dx = pd.read_csv(self.starcatFile, sep=' ', names=['ID', 'ra', 'dec', 'mag', 'dis'])
-            # Chnage IDs all to be the target
+            # Change IDs all to be the target
             dx.ID = np.ones(len(dx))
             dx.ID = dx.ID.astype('int')
             # Define data frames
@@ -228,6 +228,9 @@ class PLATOnium(object):
             picConFile = glob.glob(str(self.inputDir) + f'/starcat{extra_str}**contaminants.ftr')[0]
             df = pd.read_feather(picTarFile)
             dc = pd.read_feather(picConFile)
+
+            # Fetch LOP of catalogue
+            self.pointingField = str(Path(picTarFile).name[11:14])
             
             # Correct indicing and allow a specific star to be choosen
             if self.targetNo == 0:
@@ -402,14 +405,13 @@ class PLATOnium(object):
         # CONFIGURE PAYLOAD
 
         # Select PLATO pointing field from inputfile (e.g. SPF, NPF, etc.) [deg]
-        self.pointingField = sim["ObservingParameters/StarCatalogFile"]
-        sim["ObservingParameters/RApointing"]  = self.PF[self.pointingField][0]
-        sim["ObservingParameters/DecPointing"] = self.PF[self.pointingField][1]
+        sim["Platform/Orientation/Angles/RAPointing"]  = self.PF[self.pointingField][0]
+        sim["Platform/Orientation/Angles/DecPointing"] = self.PF[self.pointingField][1]
 
         # Solar panel orientation [deg]: Q(N) = {0, 90, 180, 270} + kappa
         kappa = self.PF[self.pointingField][2]
         solarPanelOrientationDeg = math.fmod(self.quarter * 90, 360) + kappa
-        sim["Platform/SolarPanelOrientation"] = solarPanelOrientationDeg
+        sim["Platform/Orientation/Angles/SolarPanelOrientation"] = solarPanelOrientationDeg
 
         # Set the Camera-group ID and Camera-group Alt (tilt) and Az [deg]
         sim["Telescope/GroupID"]      = self.group        
@@ -432,9 +434,9 @@ class PLATOnium(object):
             else:
                 if self.verbose > 0:
                     print('Applying pointing error      (PRE FromFile)')
-                sim["ObservingParameters/RApointing"]  += PRE[dex, 1][0]
-                sim["ObservingParameters/DecPointing"] += PRE[dex, 2][0]
-                sim["Platform/SolarPanelOrientation"]  += PRE[dex, 3][0]
+                sim["Platform/Orientation/Angles/RAPointing"]            += PRE[dex, 1][0]
+                sim["Platform/Orientation/Angles/DecPointing"]           += PRE[dex, 2][0]
+                sim["Platform/Orientation/Angles/SolarPanelOrientation"] += PRE[dex, 3][0]
 
         # Include Absolute Pointing Error (APE) due to camera misalignments
         # NOTE: Will only be included if the file "APE.txt" is available in the input folder
@@ -532,17 +534,17 @@ class PLATOnium(object):
             distortionCoefficients = None
 
         # Fetch info from YAML file since setting the subfied figure the inputfile
-        self.raPlatformDeg            = sim["ObservingParameters/RApointing"]
-        self.decPlatformDeg           = sim["ObservingParameters/DecPointing"]
+        self.raPlatformDeg            = sim["Platform/Orientation/Angles/RAPointing"]
+        self.decPlatformDeg           = sim["Platform/Orientation/Angles/DecPointing"]
+        self.solarPanelOrientationDeg = sim["Platform/Orientation/Angles/SolarPanelOrientation"]
         self.tiltTelescopeDeg         = sim["Telescope/TiltAngle"]
         self.azimuthTelescopeDeg      = sim["Telescope/AzimuthAngle"]
-        self.solarPanelOrientationDeg = sim["Platform/SolarPanelOrientation"]
         # Transform to radians
         raPlatformRad            = np.deg2rad(self.raPlatformDeg)
         decPlatformRad           = np.deg2rad(self.decPlatformDeg)
+        solarPanelOrientationRad = np.deg2rad(self.solarPanelOrientationDeg)
         tiltTelescopeRad         = np.deg2rad(self.tiltTelescopeDeg)
         azimuthTelescopeRad      = np.deg2rad(self.azimuthTelescopeDeg)
-        solarPanelOrientationRad = np.deg2rad(self.solarPanelOrientationDeg)
         # Hardware parameters
         pixelSize       = float(sim["CCD/PixelSize"])
         focalLength     = float(sim["Camera/FocalLength/ConstantValue"]) * 1000.0  # [m] -> [mm]

--- a/python/platosim/plot.py
+++ b/python/platosim/plot.py
@@ -515,9 +515,9 @@ def drawStarInFocalPlane(sim, raStar, decStar):
         isMapped               = False 
 
     pixelSize             = float(sim["CCD/PixelSize"])
-    raPlatform            = np.radians(float(sim["ObservingParameters/RApointing"]))
-    decPlatform           = np.radians(float(sim["ObservingParameters/DecPointing"]))
-    solarPanelOrientation = np.deg2rad(float(sim["Platform/SolarPanelOrientation"]))
+    raPlatform            = np.radians(float(sim["Platform/Orientation/Angles/RAPointing"]))
+    decPlatform           = np.radians(float(sim["Platform/Orientation/Angles/DecPointing"]))
+    solarPanelOrientation = np.deg2rad(float(sim["Platform/Orientation/Angles/SolarPanelOrientation"]))
     azimuthTelescope      = np.deg2rad(float(sim["Telescope/AzimuthAngle"]))
     tiltTelescope         = np.deg2rad(float(sim["Telescope/TiltAngle"]))
     focalPlaneAngle       = np.radians(float(sim["Camera/FocalPlaneOrientation/ConstantValue"]))
@@ -703,7 +703,7 @@ def drawStarInCCDfocalPlane(fig, sim, xCCD, yCCD, refCcdCode, refGroup,
         
         ra, dec = rf.platformToTelescopePointingCoordinates(np.radians(raPlatform),
                                                             np.radians(decPlatform),
-                                                            raSun, decSun,
+                                                            np.radians(solarPanelOrientation),
                                                             np.radians(azimuthAngles[group]),
                                                             np.radians(tiltAngles[group]))
 

--- a/python/platosim/simulation.py
+++ b/python/platosim/simulation.py
@@ -1324,7 +1324,7 @@ class Simulation(object):
         focalLength      = float(self["Camera/FocalLength/ConstantValue"]) * 1000.0                                   # [m] -> [mm]
         focalPlaneAngle  = np.deg2rad(float(self["Camera/FocalPlaneOrientation/ConstantValue"]))
 
-        solarPanelOrientation = self["Platform/Orientation/Angles/SolarPanelOrientation"] = math.fmod(quarter * 90. - kappa, 360.) [deg]
+        solarPanelOrientation = self["Platform/Orientation/Angles/SolarPanelOrientation"] = math.fmod(quarter * 90. - kappaPF, 360.)  # [deg]
         solarPanelOrientation = np.deg2rad(float(solarPanelOrientation))                                              # [rad]
 
         raTargetsRad  = np.deg2rad(ra)                                                                                # [rad]


### PR DESCRIPTION
Apart from this adaptation this merge also include two new features:
- The flag `--project` has been added to picsim. 
- picsim now copy an YAML file from inputfiles/ if it doesn't exist in the output directory
- platonium now automatically detects the LOP given a starcat feather file. If the user use the flag `--incat` then it is still mandatory to replace the stellar catalogue file with either `SPF` or `NPF`. 