### PR TITLE
This closes issue #725

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ### Changed
 
-* Change of HDF5 structure for Cosmics, now using consistent upper case letter for "Exposure"
-
+* Change of HDF5 structure for `Cosmics`, now using consistent upper case letter for "Exposure" (GH #765)
+* Change of YAML inputfile `Telescope` block named `UseDriftFromFile` to `DriftSource` (GH #766)
 
 
 <!-- 3.5.5 -->

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -68,7 +68,8 @@ class Simulation
         string jitterSource;
         bool includeFieldDistortion;
         bool useDrift;
-        bool useDriftFromFile;
+  // bool useDriftFromFile;
+        string driftSource;
         bool useFeeTemperatureFromFile;
         bool useFeeNominalTemperature;
         bool useDetectorTemperatureFromFile;

--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -10,7 +10,7 @@ ObservingParameters:
 
     MissionDuration:                 6.5             # Total duration of the mission [yr], relevant for BOL->EOL degradation
     NumExposures:                    10              # Number of exposures
-    BeginExposureNr:                 0               # Sequential number of first exposure. useful for slurm parallellisation
+    BeginExposureNr:                 0               # Sequential number of first exposure (useful for slurm parallellisation)
     CycleTime:                       25              # Image cycle time (exposure + readout before next exposure starts)[s]
     Fluxm0:                          1.00179e8       # Photon flux of a V=0 G2V-star [phot/s/m^2/nm]
     StarCatalogFile:                 inputfiles/starcatalog.txt
@@ -55,18 +55,17 @@ Platform:
 Telescope:
 
     GroupID:                         Custom          # There are four camera groups: 1, 2, 3, 4, Fast, Custom
-                                                     # (use Custom to specify the telescope azimuth and tilt angles)
     AzimuthAngle:                    0.0             # Azimuth angle of camera on the platform [deg] -> when GroupID = Custom
     TiltAngle:                       0.0             # Tilt    angle of camera on the platform [deg] -> when GroupID = Custom
     LightCollectingArea:             113.1           # Effective area of 1 telescope [cm^2]
     TransmissionEfficiency:
         BOL:                         0.8135          # Beginning of Life value in [0,1]
-        EOL:                         0.7945          # End of Life value in [0,1]
+        EOL:                         0.7945          # End       of Life value in [0,1]
     UseDrift:                        no              # yes or no. If no, ignore everything below.
-    UseDriftFromFile:                no              # yes or no. If yes: ignore RMS and timescale below
-    DriftYawRms:                     2.0             # RMS of thermo-elastic drift in yaw [arcsec]
+    DriftSource:                     FromRedNoise    # FromFile or FromRedNoise (use RMS and timescale below)
+    DriftYawRms:                     2.0             # RMS of thermo-elastic drift in yaw   [arcsec]
     DriftPitchRms:                   2.0             # RMS of thermo-elastic drift in pitch [arcsec]
-    DriftRollRms:                    2.0             # RMS of thermo-elastic drift in roll [arcsec]
+    DriftRollRms:                    2.0             # RMS of thermo-elastic drift in roll  [arcsec]
     DriftTimeScale:                  3600.           # Timescale of thermo-elastic drift [s]
     DriftFileName:                   inputfiles/drift.txt
 

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -131,13 +131,19 @@ Simulation::Simulation(string inputFilename, string outputFilename)
     }
     else
     {
-        if (useDriftFromFile)
+        if (driftSource == "FromFile")
         {
             driftGenerator = new ThermoElasticDriftFromFile(configParams);
         }
-        else
+        else if (driftSource == "FromRedNoise")
         {
             driftGenerator = new ThermoElasticDriftFromRedNoise(configParams);
+        }
+	else
+        {
+            string errorMessage = "Simulation: Drift Source '" + driftSource + "' is not supported.";
+            Log.error(errorMessage);
+            throw IllegalArgumentException(errorMessage);
         }
     }
 
@@ -245,7 +251,7 @@ void Simulation::configure(ConfigurationParameters &configParams)
     jitterSource                    = configParams.getString("Platform/JitterSource");
     includeFieldDistortion          = configParams.getBoolean("Camera/IncludeFieldDistortion"); // do we want to do this or should this be asked to Camera?
     useDrift                        = configParams.getBoolean("Telescope/UseDrift");
-    useDriftFromFile                = configParams.getBoolean("Telescope/UseDriftFromFile");
+    driftSource                     = configParams.getString("Telescope/DriftSource");
     psfModel                        = configParams.getString("PSF/Model");
     useFeeTemperatureFromFile       = configParams.getString("FEE/Temperature") == "FromFile";
     useFeeNominalTemperature        = configParams.getString("FEE/Temperature") == "Nominal";
@@ -727,7 +733,7 @@ void Simulation::writeInputParametersToHDF5(ConfigurationParameters &configParam
     addDouble("TiltAngle");
     addDouble("LightCollectingArea");
     addBoolean("UseDrift");
-    addBoolean("UseDriftFromFile");
+    addString("DriftSource");
     addDouble("DriftYawRms");
     addDouble("DriftPitchRms");
     addDouble("DriftRollRms");

--- a/tests/validationTests/scripts/ThermoElasticDrift/tedFromFile.py
+++ b/tests/validationTests/scripts/ThermoElasticDrift/tedFromFile.py
@@ -33,7 +33,7 @@ class TedFromFile(Test):
         readoutTime                                       = self.sim.getReadoutTime()[0]
         self.sim["ObservingParameters/NumExposures"]      = self.numExposures
         self.sim["Telescope/UseDrift"]                    = "yes"
-        self.sim["Telescope/UseDriftFromFile"]            = "yes"
+        self.sim["Telescope/DriftSource"]                 = "FromFile"
         self.sim["ControlHDF5Content/WriteStarPositions"] = "yes"
         self.sim["SubField/NumRows"]                      = 1000
         self.sim["SubField/NumColumns"]                   = 1000


### PR DESCRIPTION
Close #725 : update of inconsistent notation of the YAML file from `UseDriftFromFile` to `DriftSource` for the `Telescope` block. This update is made now to be included in the new release which already have multiple backward compatibility breaking points. 