### PR TITLE
Allow indefinite timeout

### DIFF
--- a/inputfiles/inputfile_FCAM_required.yaml
+++ b/inputfiles/inputfile_FCAM_required.yaml
@@ -286,15 +286,13 @@ ControlHDF5Content:
     
 ControlTcpConnection:
 
-    SendImagettesToClients:         no
-    GetWindowPositionsFromServer:   no
-
-    WindowPositionServerAddress:    tcp://localhost:5558
-    JitterServerAddress:            tcp://localhost:5559
-    ImagetteClientAddress:          tcp://localhost:5560
-
-    WindowPositionSocketTimeout:    100  # seconds
-    JitterSocketTimeout:            100  # seconds
+    SendImagettesToClients:          no
+    GetWindowPositionsFromServer:    no
+    WindowPositionServerAddress:     tcp://localhost:5558
+    JitterServerAddress:             tcp://localhost:5559
+    ImagetteClientAddress:           tcp://localhost:5560
+    WindowPositionSocketTimeout:     100  # [s]
+    JitterSocketTimeout:             100  # [s]
 
 
 # ----- DO NOT MAKE CHANGES BELOW THIS LINE -----

--- a/source/ClosedLoopUtility.cpp
+++ b/source/ClosedLoopUtility.cpp
@@ -55,7 +55,16 @@ void ClosedLoopUtility::configure(ConfigurationParameters &configParams)
     getWindowPositionFromServer     = configParams.getBoolean("ControlTcpConnection/GetWindowPositionsFromServer");
     imagetteAddress                 = configParams.getString("ControlTcpConnection/ImagetteClientAddress");
     windowPositionAddress           = configParams.getString("ControlTcpConnection/WindowPositionServerAddress");
-    windowPositionSocketTimeout     = configParams.getInteger("ControlTcpConnection/WindowPositionSocketTimeout") * 1000;
+    windowPositionSocketTimeout     = configParams.getInteger("ControlTcpConnection/WindowPositionSocketTimeout");
+
+    if (windowPositionSocketTimeout < 0)
+    {
+        windowPositionSocketTimeout = -1;
+    }
+    else
+    {
+        windowPositionSocketTimeout *= 1000;
+    }
 
 }
 

--- a/source/JitterFromNetwork.cpp
+++ b/source/JitterFromNetwork.cpp
@@ -76,7 +76,16 @@ void JitterFromNetwork::configure(ConfigurationParameters &configParams)
 
     jitterAddress = configParams.getString("ControlTcpConnection/JitterServerAddress");
 
-    jitterSocketTimeout = configParams.getInteger("ControlTcpConnection/JitterSocketTimeout") * 1000;
+    jitterSocketTimeout = configParams.getInteger("ControlTcpConnection/JitterSocketTimeout");
+
+    if (jitterSocketTimeout < 0)
+    {
+        jitterSocketTimeout = -1;
+    }
+    else
+    {
+        jitterSocketTimeout *= 1000;
+    }
 
 }
 

--- a/tests/closedLoopTest/offlineInput.yaml
+++ b/tests/closedLoopTest/offlineInput.yaml
@@ -294,15 +294,13 @@ ControlHDF5Content:
 
 ControlTcpConnection:
 
-    SendImagettesToClients:         no
-    GetWindowPositionsFromServer:   no
-
-    WindowPositionServerAddress: tcp://localhost:5558
-    JitterServerAddress:         tcp://localhost:5559
-    ImagetteClientAddress:       tcp://localhost:5560
-
-    WindowPositionSocketTimeout:    10000  # seconds
-    JitterSocketTimeout:            10000  # seconds
+    SendImagettesToClients:          no
+    GetWindowPositionsFromServer:    no
+    WindowPositionServerAddress:     tcp://localhost:5558
+    JitterServerAddress:             tcp://localhost:5559
+    ImagetteClientAddress:           tcp://localhost:5560
+    WindowPositionSocketTimeout:     10000  # [s]
+    JitterSocketTimeout:             10000  # [s]
 
 
 # ----- DO NOT MAKE CHANGES BELOW THIS LINE -----

--- a/tests/closedLoopTest/onlineInput.yaml
+++ b/tests/closedLoopTest/onlineInput.yaml
@@ -298,8 +298,8 @@ ControlTcpConnection:
     WindowPositionServerAddress:     tcp://localhost:5558
     JitterServerAddress:             tcp://localhost:5559
     ImagetteClientAddress:           tcp://localhost:5560
-    WindowPositionSocketTimeout:     100  # [s]
-    JitterSocketTimeout:             100  # [s]
+    WindowPositionSocketTimeout:     10000  # [s]
+    JitterSocketTimeout:             10000  # [s]
 
 
 # ----- DO NOT MAKE CHANGES BELOW THIS LINE -----

--- a/tests/closedLoopTest/onlineInput.yaml
+++ b/tests/closedLoopTest/onlineInput.yaml
@@ -293,8 +293,8 @@ ControlHDF5Content:
 
 ControlTcpConnection:
 
-    SendImagettesToClients:          no
-    GetWindowPositionsFromServer:    no
+    SendImagettesToClients:          yes
+    GetWindowPositionsFromServer:    yes
     WindowPositionServerAddress:     tcp://localhost:5558
     JitterServerAddress:             tcp://localhost:5559
     ImagetteClientAddress:           tcp://localhost:5560

--- a/tests/closedLoopTest/onlineInput.yaml
+++ b/tests/closedLoopTest/onlineInput.yaml
@@ -293,15 +293,13 @@ ControlHDF5Content:
 
 ControlTcpConnection:
 
-    SendImagettesToClients:         yes
-    GetWindowPositionsFromServer:   yes
-
-    WindowPositionServerAddress: tcp://localhost:5558
-    JitterServerAddress:         tcp://localhost:5559
-    ImagetteClientAddress:       tcp://localhost:5560
-
-    WindowPositionSocketTimeout:    10000  # seconds
-    JitterSocketTimeout:            10000  # seconds
+    SendImagettesToClients:          no
+    GetWindowPositionsFromServer:    no
+    WindowPositionServerAddress:     tcp://localhost:5558
+    JitterServerAddress:             tcp://localhost:5559
+    ImagetteClientAddress:           tcp://localhost:5560
+    WindowPositionSocketTimeout:     100  # [s]
+    JitterSocketTimeout:             100  # [s]
 
 
 # ----- DO NOT MAKE CHANGES BELOW THIS LINE -----


### PR DESCRIPTION
This pull request supersedes the PR #826 

The case for indefinite timeout is handled separately to keep the unit at seconds instead of ms.