### PR TITLE
Changes to HDF5 output and python functions

### DIFF
--- a/include/Detector.h
+++ b/include/Detector.h
@@ -274,6 +274,7 @@ class Detector: public HDF5Writer
         bool writeBackgroundMap;                  // Wheter or not to write the background map to the HDF5 file.
         bool writeSmearingMaps;                  // Whether or not to write the smearing maps to the HDF5 file, for each exposure
         bool writeThroughputMaps;                // Whether or not to write the throughput maps to the HDF5 file, for each exposure
+        bool writeFlatfieldMap;                  // Whether or not to write the flatfield map to the HDF5 file, for each exposure  
         bool writeCosmics;                       // Whether or not to write the cosmics row, column and flux to the HDF5 file, for each exposure
         bool writeCTI;                           // Whether or not to write the BOL/EOL trap density maps for each species to the HDF5 file
 

--- a/include/PointSpreadFunction.h
+++ b/include/PointSpreadFunction.h
@@ -36,6 +36,8 @@ class PointSpreadFunction : public HDF5Writer
         arma::fmat getOriginalPSF();
         vector<std::array<double, 4>> getDistortionMap();
         bool writeHighResolutionPSF;
+        bool writeDiffusedPSF;
+        bool includeChargeDiffusion;
         vector<std::array<double, 4>> distortionMap;
 
     protected:

--- a/python/platosim/lightcurve.py
+++ b/python/platosim/lightcurve.py
@@ -978,7 +978,7 @@ class LightCurve(object):
             flux         = df[column]    / 1e3  # [ke-/s]
             flux_trend   = df.flux_trend / 1e3  # [ke-/s]
         elif column == 'flux_stitch':
-            ylab1      = 'Flux [ppt]'
+            ylab0      = 'Flux [ppt]'
             flux       = df[column]             # [ppt]
             flux_trend = df.flux_trend          # [ppt]
 

--- a/python/platosim/platonium/vizier.py
+++ b/python/platosim/platonium/vizier.py
@@ -152,9 +152,9 @@ class StarQuery(object):
         filename = self.odir / f'starcat_GaiaDR3_{self.field}'
         N = len(self.raGrid)
         
-        # for i in tqdm(range(N), bar_format=ut.tqdmBar()):
-        #     sq.gaiaRegionQuery(self.raGrid[i], self.decGrid[i], radius=self.r,
-        #                        maglim=self.maglim, ofile=f'{filename}_grid{i+1}')
+        for i in tqdm(range(N), bar_format=ut.tqdmBar()):
+            sq.gaiaRegionQuery(self.raGrid[i], self.decGrid[i], radius=self.r,
+                               maglim=self.maglim, ofile=f'{filename}_grid{i+1}')
 
         # Combine all the data sets
 

--- a/python/platosim/simfile.py
+++ b/python/platosim/simfile.py
@@ -125,7 +125,7 @@ class SimFile (object):
 
 
 
-    def getTime(self):
+    def getTime(self, df=False):
 
         """Get the time points according to the CCD cadence [s].
         """
@@ -138,9 +138,14 @@ class SimFile (object):
         # TODO fix this in future!
         if ccdCode == "Custom": ccdCode = "1"
         timeShift = self.getInputParameter("CCDPositions", "TimeShift")[int(ccdCode)-1]
-        timeArray = np.arange(beginExposure, beginExposure + numExposures) * cadence + timeShift
+        timeArray = np.arange(beginExposure, beginExposure+numExposures) * cadence+timeShift
 
-        return pd.DataFrame({"time": timeArray}) 
+        # Return time points
+
+        if df:
+            return pd.DataFrame({"time": timeArray})
+        else:
+            return timeArray
 
     
 
@@ -925,7 +930,7 @@ class SimFile (object):
     #--------------------------------------------------------------#
 
 
-    def getStarCatalog(self):
+    def getStarCatalog(self, df=False):
 
         """Get the stellar catalogue.
 
@@ -943,7 +948,8 @@ class SimFile (object):
 
         Parameters
         ----------
-        None
+        df : bool
+            Flag to save stellar catalogue to a pandas data frame
 
         Returns
         -------
@@ -954,7 +960,7 @@ class SimFile (object):
             Right ascension of stars [deg]
         dec : ndarray
             Declination of stars [deg]
-        Vmag : ndarray
+        mag : ndarray
             V magnitude of stars
         xFPmm : ndarray
             Initial planar X focal plane coordinates of the stars [mm]
@@ -986,32 +992,38 @@ class SimFile (object):
 
         # Extract the data from the HDF5 file
 
-        starIDs = self.hdf5file["StarCatalog"]["starIDs"][:]
-        RA      = self.hdf5file["StarCatalog"]["RA"][:]
-        dec     = self.hdf5file["StarCatalog"]["Dec"][:]
-        Vmag    = self.hdf5file["StarCatalog"]["Vmag"][:]
+        ID  = self.hdf5file["StarCatalog"]["starIDs"][:]
+        ra  = self.hdf5file["StarCatalog"]["RA"][:]
+        dec = self.hdf5file["StarCatalog"]["Dec"][:]
+        mag = self.hdf5file["StarCatalog"]["Vmag"][:]
 
         # xFPmm, yFPmm, rowPix, and colPix were all introduced with the same commit
         # So, testing if xFPmm is present in the StarCatalog group is sufficient
 
         if "xFPmm" in self.hdf5file["StarCatalog"].keys():
             
-            xFPmm  = self.hdf5file["StarCatalog"]["xFPmm"][:]
-            yFPmm  = self.hdf5file["StarCatalog"]["yFPmm"][:]
-            colPix = self.hdf5file["StarCatalog"]["colPix"][:]
-            rowPix = self.hdf5file["StarCatalog"]["rowPix"][:]
+            xFP  = self.hdf5file["StarCatalog"]["xFPmm"][:]
+            yFP  = self.hdf5file["StarCatalog"]["yFPmm"][:]
+            xCCD = self.hdf5file["StarCatalog"]["colPix"][:]
+            yCCD = self.hdf5file["StarCatalog"]["rowPix"][:]
 
-            return starIDs, RA, dec, Vmag, xFPmm, yFPmm, rowPix, colPix
+            if df:
+                return pd.DataFrame({'ID':ID, 'ra':ra, 'dec':dec, 'mag':mag,
+                                     'xFP':xFP, 'yFP':yFP, 'xPix':xCCD, 'yPix':yCCD})
+            else:
+                return ID, ra, dec, mag, xFP, yFP, xCCD, yCCD
 
-        # That's it!
+        else:
+            if df:
+                return pd.DataFrame({'ID':ID, 'ra':ra, 'dec':dec, 'mag':mag})
+            else:
+                return ID, ra, dec, mag, None, None, None, None
 
-        return starIDs, RA, dec, Vmag, None, None, None, None
 
 
 
 
-
-    def getCoordinates(self, groupName, imageNr, minVmag=None, maxVmag=None):
+    def getCoordinates(self, groupName, imageNr, minMag=None, maxMag=None, df=False):
 
         """General function to get coordinate information.
 
@@ -1022,14 +1034,16 @@ class SimFile (object):
         ----------
         imageNr : int 
             Integer sequential number of the image in the HDF5 file.
-        minVmag : int, float
-            Min V magnitude of the stars causing the point-like ghosts. 
-            Only return ghosts for which the originating star is fainter than minVmag.
+        minMag : int, float
+            Min magnitude of the objects detected on the CCD subfield.
+            Only return objects brighter than minMag.
             Should be 'None' if no cut in minimum magnitude should be made.
-        maxVmag : int, float
-            Maximum V magnitude of the stars causing the point-like ghosts. 
-            Only return ghosts for which the originating star is brighter than maxVmag.
+        maxMag : int, float
+            Maximum magnitude of the objects detected on the CCD subfield.
+            Only return objects fainter than maxMag.
             Should be 'None' if no cut in maximum magnitude should be made.
+        df : bool
+            Flag to save stellar catalogue to a pandas data frame
 
         Return
         ------
@@ -1055,7 +1069,7 @@ class SimFile (object):
           ghosts during the exposure.
         - To get the pixel with the higest flux of star #0, given its (row, col) coordinates:
           >>> im = file.getImage(0)
-          >>> ID,row,col,Xmm,Ymm,flux = file.getPointLikeGhostCoordinates(4,minVmag=6.0,maxVmag=9.0)
+          >>> ID,row,col,Xmm,Ymm,flux = file.getPointLikeGhostCoordinates(4,minMag=6.0,maxMag=9.0)
           >>> im[int(row[0]), int(col[0])]
         - To use this function to overplot the positions of the point-like ghost on an 
           image plotted by showImage(), use plt.scatter(floor(col), floor(row)) because 
@@ -1145,47 +1159,64 @@ class SimFile (object):
             if groupName == "ExtendedGhostPositions":
                     
                 radius = np.array([self.hdf5file[groupName][s]["radius"][imageNr] for s in star])
-
                 
         # If no cut in V magnitude is required, we're finished.
 
-        if (minVmag == None) and (maxVmag == None):
+        if (minMag == None) and (maxMag == None):
             
             if groupName == "ExtendedGhostPositions":
-                return starID, row, col, Xmm, Ymm, flux, radius
+                if df:
+                    return pd.DataFrame({'ID':starID, 'row':row, 'col':col,
+                                         'xFP':Xmm, 'yFP':Ymm, 'flux':flux,
+                                         'radius':radius})
+                else:
+                    return starID, row, col, Xmm, Ymm, flux, radius
             else:
-                return starID, row, col, Xmm, Ymm, flux
+                if df:
+                    pd.DataFrame({'ID':starID, 'row':row, 'col':col,
+                                  'xFP':Xmm, 'yFP':Ymm, 'flux':flux})
+                else:
+                    return starID, row, col, Xmm, Ymm, flux
         
         # If a cut in magnitude is required, get the magnitudes from the star input catalogue
 
-        inputStarIDs, _, _, Vmag, _, _, _, _ = self.getStarCatalog()
-        subFieldVmag = Vmag[np.in1d(inputStarIDs, starID)]
+        inputStarIDs, _, _, mag, _, _, _, _ = self.getStarCatalog()
+        subFieldMag = mag[np.in1d(inputStarIDs, starID)]
 
         # If the min or max V magnitude is set to None, use the default values
 
-        if minVmag == None:
-            minVmag = subFieldVmag.min()
-        if maxVmag == None:
-            maxVmag = subFieldVmag.max()
+        if minMag == None:
+            minMag = subFieldMag.min()
+        if maxMag == None:
+            maxMag = subFieldMag.max()
 
         # Make the magnitude cut
 
-        selection = (subFieldVmag >= minVmag) & (subFieldVmag <= maxVmag)
+        dex = (subFieldMag >= minMag) & (subFieldMag <= maxMag)
 
         # Return after stellar cut
 
         if groupName == "ExtendedGhostPositions":
-            return (starID[selection], row[selection], col[selection],
-                    Xmm[selection], Ymm[selection], flux[selection], radius[selection])
+            if df:
+                return pd.DataFrame({'ID':starID[dex], 'row':row[dex], 'col':col[dex],
+                                     'xFP':Xmm[dex], 'yFP':Ymm[dex], 'flux':flux[dex],
+                                     'radius':radius[dex]})
+            else:
+                return (starID[dex], row[dex], col[dex],
+                        Xmm[dex], Ymm[dex], flux[dex], radius[dex])
+            
         else:
-            return (starID[selection], row[selection], col[selection],
-                    Xmm[selection], Ymm[selection], flux[selection])
+            if df:
+                return pd.DataFrame({'ID':starID[dex], 'row':row[dex], 'col':col[dex],
+                                     'xFP':Xmm[dex], 'yFP':Ymm[dex], 'flux':flux[dex]})
+            else:
+                return (starID[dex], row[dex], col[dex], Xmm[dex], Ymm[dex], flux[dex])
 
     
     
 
         
-    def getStarCoordinates(self, imageNr, minVmag=None, maxVmag=None):
+    def getStarCoordinates(self, imageNr, minMag=None, maxMag=None, df=False):
 
         """Get star information.
 
@@ -1194,13 +1225,13 @@ class SimFile (object):
         See parameters and returns for this function.
         """
 
-        return self.getCoordinates("StarPositions", imageNr, minVmag, maxVmag)
+        return self.getCoordinates("StarPositions", imageNr, minMag, maxMag, df)
 
 
 
     
 
-    def getPointLikeGhostCoordinates(self, imageNr, minVmag=None, maxVmag=None):
+    def getPointLikeGhostCoordinates(self, imageNr, minMag=None, maxMag=None, df=False):
 
         """Get point-like ghost information.
                 
@@ -1209,13 +1240,13 @@ class SimFile (object):
         See parameters and returns for this function.
         """
 
-        return self.getCoordinates("PointLikeGhostPositions", imageNr, minVmag, maxVmag)
+        return self.getCoordinates("PointLikeGhostPositions", imageNr, minMag, maxMag, df)
 
 
 
 
     
-    def getExtendedGhostCoordinates(self, imageNr, minVmag=None, maxVmag=None):
+    def getExtendedGhostCoordinates(self, imageNr, minMag=None, maxMag=None, df=False):
 
         """Get point-like ghost information.
                 
@@ -1224,13 +1255,13 @@ class SimFile (object):
         See parameters and returns for this function.
         """
         
-        return self.getCoordinates("ExtendedGhostPositions", imageNr, minVmag, maxVmag)
+        return self.getCoordinates("ExtendedGhostPositions", imageNr, minMag, maxMag, df)
 
 
 
 
     
-    def getStarPositions(self, starID):
+    def getStarPositions(self, starID, getTime=False, df=False):
 
         """Get stellar pixel positions
 
@@ -1249,7 +1280,12 @@ class SimFile (object):
         col : ndarray
             Pixel column coordinates of each star in the image (float).
         """
-        
+
+        # Get the time column
+
+        if getTime:
+            time = self.getTime()
+
         # Check if the point-like ghost info was saved to the HDF5 file
 
         groupName = "StarPositions"
@@ -1294,8 +1330,18 @@ class SimFile (object):
             col = self.hdf5file[groupName][star]["colPix"][:]
 
         # That's it!
-        
-        return row, col
+
+        if getTime:
+            if df:
+                return pd.DataFrame({'time':time, 'row':row, 'col':col})
+            else:
+                return time, row, col
+            
+        else:
+            if df:
+                return pd.DataFrame({'row':row, 'col':col})
+            else:
+                return row, col
 
 
 
@@ -1306,7 +1352,7 @@ class SimFile (object):
     #--------------------------------------------------------------#
 
 
-    def getCosmicsInfo(self, imageNr, field="SubField"):
+    def getCosmicsInfo(self, imageNr, field="SubField", df=False):
 
         """Get information about cosmic rays in the pixel maps.
         
@@ -1402,16 +1448,24 @@ class SimFile (object):
         # That's it!
 
         if len(intensities) == 1 and intensities[0] == -1.0:
-            empty = np.array([])
-            return empty, empty, empty, empty, empty
+            if df:
+                return pd.DataFrame()
+            else:
+                empty = np.array([])
+                return empty, empty, empty, empty, empty
         else:
-            return entryRows, entryColumns, entryAngles, intensities, trailLengths
+            if df:
+                return pd.DataFrame({'entryRows':entryRows, 'entryColumns':entryColumns,
+                                     'entryAngles':entryAngles, 'intensities':intensities,
+                                     'trailLengths':trailLengths})
+            else:
+                return entryRows, entryColumns, entryAngles, intensities, trailLengths
 
 
         
 
 
-    def getCosmicsAffectedPixels(self, imageNr, field="SubField"):
+    def getCosmicsAffectedPixels(self, imageNr, field="SubField", df=False):
 
         """Get the pixel affected by cosmic rays.
 
@@ -1489,7 +1543,10 @@ class SimFile (object):
 
         # That's it!
 
-        return row, col, flux
+        if df:
+            return pd.DataFrame({'row':row, 'col':col, 'flux':flux})
+        else:
+            return row, col, flux
 
 
 
@@ -1911,7 +1968,7 @@ class SimFile (object):
 
     def showImage(self, imageNr=False, imgScale="percentile", clip=5.0,
                   showStarPositions=False, showPointLikeGhostPositions=False,
-                  minVmag=None, maxVmag=None, showStarIDs=False,
+                  minMag=None, maxMag=None, showStarIDs=False,
                   tarMarkerSize=200, showMaskOfStarID=None,
                   useTitle=False, showGrid=False, colorBar=True, colorMap="cubehelix",
                   origin="lower", fontSize=15, figsize=(8,8)):
@@ -1938,10 +1995,10 @@ class SimFile (object):
         showPointLikeGhostPositions: bool
             False : Default
             True  : Plot the average pointlike ghost position (averaged over the exposure)
-        minVmag: int, float
+        minMag: int, float
             The minimum V magnitude of the stars/ghosts for which the position should be plotted.
             Only relevant if either showStarPositions or showPointLikeGhostPositions is True.
-        maxVmag: int, float
+        maxMag: int, float
             The maximum V magnitude of the stars/ghosts for which the position should be plotted.
             Only relevant if either showStarPositions or showPointLikeGhostPositions is True.
         showStarIDs: bool
@@ -2072,8 +2129,8 @@ class SimFile (object):
 
         if showStarPositions:
             ID, row, col, Xmm, Ymm, flux = self.getStarCoordinates(imageNr,
-                                                                   minVmag=minVmag,
-                                                                   maxVmag=maxVmag)
+                                                                   minMag=minMag,
+                                                                   maxMag=maxMag)
             # Set linewidth of marker
 
             lw = 0.06 * fontSize
@@ -2112,8 +2169,8 @@ class SimFile (object):
 
         if showPointLikeGhostPositions:
             ID, row, col, Xmm, Ymm, flux = self.getPointLikeGhostCoordinates(imageNr,
-                                                                             minVmag=minVmag,
-                                                                             maxVmag=maxVmag)
+                                                                             minMag=minMag,
+                                                                             maxMag=maxMag)
             ax.scatter(col, row, marker='o', s=6, c='b')
             if showStarIDs:
                 for k in range(len(ID)):

--- a/python/platosim/simfile.py
+++ b/python/platosim/simfile.py
@@ -75,6 +75,7 @@ class SimFile (object):
     def reload(self):
 
         """Close the file, and reload it.
+
         Useful when the file may have changed meanwhile.
         """
 
@@ -86,7 +87,9 @@ class SimFile (object):
 
 
     def checkPhotometry(self):
-        # Check that photometry has been saved
+
+        """Check that photometry has been saved.
+        """
 
         if "Photometry" not in self.hdf5file["/"].keys():
             print("ERROR: No photometry present in the HDF5 file!")
@@ -120,11 +123,6 @@ class SimFile (object):
 
 
 
-
-    
-    #--------------------------------------------------------------#
-    #                    SIMULATION PARAMETERS                     #
-    #--------------------------------------------------------------#
 
 
     def getTime(self):
@@ -347,6 +345,9 @@ class SimFile (object):
         
         return np.sqrt(ronCCD**2 + ronFEE**2)
 
+
+
+    
     
     #--------------------------------------------------------------#
     #                          IMAGE MAPS                          #
@@ -599,11 +600,13 @@ class SimFile (object):
     #--------------------------------------------------------------#
 
 
-    def saveHighResolutionPSFtoFITS(self, FITSfileName):
-        """
-        In case of the analytic non-Gaussian PSF, a high-resolution PSF corresponding to the center
-        of the subfield is stored in the HDF5 file. Extract this image and save it to a FITS file
-        This function will fail when PlatoSim was not run with an analytic non-Gaussian PSF.
+    def saveHighResPSFtoFITS(self, FITSfileName):
+
+        """Save the high resolution PSF to a FITS file.
+
+        In case of the analytic non-Gaussian PSF, a high-resolution PSF corresponding
+        to the center of the subfield is stored in the HDF5 file. Extract this image
+        and save it to a FITS file.
         """
 
         imageName = "HighResPSFmapCenterSubfield"
@@ -623,7 +626,9 @@ class SimFile (object):
 
 
     def saveImagesToFITS(self, fileName):
-        """
+
+        """Save the image maps to a FITS file.
+
         Save all subfield images in the HDF5 file to a FITS file with the given file name.
         This will go horribly wrong when the number of images is too large or when the images
         themselves are too large.
@@ -650,7 +655,9 @@ class SimFile (object):
 
 
     def saveSmearingMapsToFITS(self, fileName):
-        """
+
+        """Save the smearing maps to a fits file.
+
         Save all smearing maps in the HDF5 file to a FITS file with the given file name.
         This will go horribly wrong when the number of exposures is too large or when the maps
         themselves are too large.
@@ -675,7 +682,9 @@ class SimFile (object):
 
 
     def saveBiasMapsLeftToFITS(self, fileName):
-        """
+
+        """Save the left bias maps to a FITS file.
+
         Save all bias maps in the HDF5 file to a FITS file with the given file name.
         This will go horribly wrong when the number of exposures is too large or when the maps
         themselves are too large.
@@ -700,7 +709,9 @@ class SimFile (object):
 
 
     def saveBiasMapRightToFITS(self, fileName):
-        """
+
+        """Save the right bias maps to a FITS file.
+
         Save all bias maps in the HDF5 file to a FITS file with the given file name.
         This will go horribly wrong when the number of exposures is too large or when the maps
         themselves are too large.
@@ -725,135 +736,190 @@ class SimFile (object):
 
         
     #--------------------------------------------------------------#
-    #                      PLATFORM & TELESCOPE                    #
+    #                     PLATFORM & TELESCOPE                     #
     #--------------------------------------------------------------#
 
 
-    def getYawPitchRoll(self, getTime=False):
+    def getPayloadInfo(self, groupName, subGroup, getTime, df):
 
-        """Get (yaw, pitch, roll) of platform.
+        """Get all columns saved to the telescope entry.
         
-        Get the yaw, pitch and roll angle values of the platform pointng
-        at the end of each exposure.
+        The telescope information contains information about the telescope 
+        jitter and pointing. This implies: time, (yaw, pitch, roll) angles,
+        and (RA, Dec) of the telescope pointing. The cadence is equal to the
+        time scale set in the YAML configuration file.
 
         Parameters
         ----------
         getTime : bool
-            If True the function also returns the jitter time
+            If "True" also the time points are returned
 
         Returns
         -------
+        time : ndarray
+            Time point [s]
         yaw : ndarray
-            Yaw of platform pointing [arcsec]
+            Yaw of the telescope pointing [arcsec]
         pitch : ndarray
-            Pitch of platform pointing [arcsec]
+            Pitch of the telescope pointing [arcsec]
         roll : ndarray
-            Roll of platform pointing [arcsec]
-
-        Notes
-        -----
-        The yaw, pitch, roll values at the end of an exposure are not the
-        same as the ones at the beginning of the next exposure, because 
-        between two exposures there is the CCD readout time during which
-        the ACS jitter continues.
+            Roll of the telescope pointing [arcsec]
+        alpha : ndarray
+            Right acsension of the telescope pointing [deg]
+        delta : ndarray
+            Declination of the telescope pointing [deg]
         """
+
+        # TODO change code to be exact the sam entries!
+
+        if groupName == 'ACS':
+            stringRA    = 'platformRA'
+            stringDec   = 'platformDec'
+            stringYaw   = 'yaw'
+            stringPitch = 'pitch'
+            stringRoll  = 'roll'
+        elif groupName == 'Telescope':
+            stringRA    = 'telescopeRA'
+            stringDec   = 'telescopeDec'
+            stringYaw   = 'telescopeYaw'
+            stringPitch = 'telescopePitch'
+            stringRoll  = 'telescopeRoll'
 
         # Extract arrays
 
-        yaw   = self.hdf5file["ACS"]["yaw"][:]
-        pitch = self.hdf5file["ACS"]["pitch"][:]
-        roll  = self.hdf5file["ACS"]["roll"][:]
-
-        # Extract the time values - That's it!
-        
         if getTime:
-            time = self.hdf5file["Time"]["time"][:]
-            return yaw, pitch, roll, time
-        else:
-            return yaw, pitch, roll
+            time  = self.hdf5file[groupName]["time"][:]
+
+        if subGroup in ['info', 'pointing']:
+            alpha = self.hdf5file[groupName][stringRA][:]
+            delta = self.hdf5file[groupName][stringDec][:]
+            
+        if subGroup in ['info', 'angles']:
+            pitch = self.hdf5file[groupName][stringYaw][:]
+            roll  = self.hdf5file[groupName][stringPitch][:]
+            yaw   = self.hdf5file[groupName][stringRoll][:]
+            
+        # Return requested columns
+
+        if subGroup == 'info':
+            if df:
+                return pd.DataFrame({'time':time, 'alpha':alpha, 'delta':delta,
+                                     'yaw':yaw, 'pitch':pitch, 'roll':roll})
+            else:
+                return time, alpha, delta, yaw, pitch, roll
+
+        elif subGroup == 'pointing':
+            if getTime:
+                if df:
+                    return pd.DataFrame({'time':time, 'alpha':alpha, 'delta':delta})
+                else:
+                    return time, alpha, delta
+            else:
+                if df:
+                    return pd.DataFrame({'alpha':alpha, 'delta':delta})
+                else:
+                    return alpha, delta
+            
+        elif subGroup == 'angles':
+            if getTime:
+                if df:
+                    return pd.DataFrame({'time':time, 'yaw':yaw, 'pitch':pitch, 'roll':roll})
+                else:
+                    return time, yaw, pitch, roll
+            else:
+                if df:
+                    return pd.DataFrame({'yaw':yaw, 'pitch':pitch, 'roll':roll})
+                else:
+                    return yaw, pitch, roll
+
+            
 
 
+                
+    def getPlatformInfo(self, df=False):
 
+        """Get platform information.
 
-
-    def getYawPitchRollFromDrift(self, getTime=False):
+        This function use the general 'getPayloadInfo' function to fetch
+        the information contained in the 'ACS' HDF5 group.
         """
-        Get the camera yaw, pitch and roll angle values at the end of each exposure.
 
-        Parameters
-        ----------
-        getTime : bool
-            If True the function also returns the jitter time
+        return self.getPayloadInfo("ACS", "info", True, df)
 
-        Returns
-        -------
-        yaw : ndarray
-            Yaw of platform pointing [arcsec]
-        pitch : ndarray
-            Pitch of platform pointing [arcsec]
-        roll : ndarray
-            Roll of platform pointing [arcsec]
 
-        Notes
-        -----
-        The yaw, pitch, roll values at the end of an exposure are not the
-        same as the ones at the beginning of the next exposure, because 
-        between two exposures there is the CCD readout time during which
-        the drift continues.
+
+
+
+    def getPlatformPointingCoordinates(self, getTime=False, df=False):
+
+        """Get platform pointing coordinates.
+
+        This function use the general 'getPayloadInfo' function to fetch
+        the pointing coordinates contained in the 'Platform' HDF5 group.
         """
 
-        # Extract arrays
+        return self.getPayloadInfo("ACS", "pointing", getTime, df)
 
-        yaw   = self.hdf5file["Telescope"]["telescopeYaw"][:]
-        pitch = self.hdf5file["Telescope"]["telescopePitch"][:]
-        roll  = self.hdf5file["Telescope"]["telescopeRoll"][:]
 
-        # Extract the time values
+
+
+
+    def getPlatformYawPitchRoll(self, getTime=False, df=False):
+
+        """Get platform jitter information.
+
+        This function use the general 'getPayloadInfo' function to fetch
+        the jitter information contained in the 'Platform' HDF5 group.
+        """
+
+        return self.getPayloadInfo("ACS", "angles", getTime, df)
+
+
+
+
+
+    def getTelescopeInfo(self, df=False):
+
+        """Get telescope information.
+
+        This function use the general 'getPayloadInfo' function to fetch
+        the information contained in the 'Telescope' HDF5 group.
+        """
+
+        return self.getPayloadInfo("Telescope", "info", True, df)
+
+
+
+
+
+    def getTelescopePointingCoordinates(self, getTime=False, df=False):
+
+        """Get telescope pointing coordinates.
+
+        This function use the general 'getPayloadInfo' function to fetch
+        the information contained in the 'Telescope' HDF5 group.
+        """
+
+        return self.getPayloadInfo("Telescope", "pointing", getTime, df)
+
+
+
+
+
+    def getTelescopeYawPitchRoll(self, getTime=False, df=False):
+
+        """Get telescope drift information.
+
+        This function use the general 'getPayloadInfo' function to fetch
+        the pointing information contained in the 'Telescope' HDF5 group.
+        """
+
+        return self.getPayloadInfo("Telescope", "angles", getTime, df)
+    
+
+
+
         
-        if getTime:
-            time = self.hdf5file["Time"]["time"][:]
-            return yaw, pitch, roll, time
-        else:
-            return yaw, pitch, roll
-
-
-
-
-
-    def getPlatformPointingCoordinates(self): # TODO add kappa to output file!
-
-        """Get the pointing of platform.
-
-        Get the RA and Dec values of the Platform pointing axis
-        at the end of each exposure.
-
-        Returns
-        -------
-        RA : ndarray
-            Right ascension of platform pointing [deg]
-        dec : ndarray
-            Declination of platform pointing [deg]
-
-        Notes
-        -----
-        The coordinate values at the end of an exposure are not the same
-        as the ones at the beginning of the next exposure, because between
-        two exposures there is the CCD readout time during which the ACS
-        jitter continues.
-        """
-
-        alpha = self.hdf5file["ACS"]["platformRA"][:]
-        delta = self.hdf5file["ACS"]["platformDec"][:]
-        #kappa = self.hdf5file["Platform"]["SolarPanelOrientation"][:]
-        
-        # That's it
-
-        return alpha, delta
-
-
-
-
-
     #--------------------------------------------------------------#
     #                       STELLAR INFORMATION                    #
     #--------------------------------------------------------------#

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -77,17 +77,19 @@ Camera::~Camera()
  * \brief Creates the group(s) in the HDF5 file where the star information will be stored.
  *        These group(s) have to be created once, at the very beginning.
  */
-
 void Camera::initHDF5Groups()
 {
     Log.debug("Camera: initialising HDF5 groups");
 
-    hdf5File.createGroup("/StarPositions");
+    if (writeStarPositions)
+      {
+	hdf5File.createGroup("/StarPositions");
+      }
+    
     if (writeTransmissionEfficiency)
     {
       hdf5File.createGroup("/TransmissionEfficiency");
     }
-
 }
 
 
@@ -228,21 +230,21 @@ pair<starInfoIterator, starInfoIterator> Camera::getInfoForTheMostRecentExposure
 void Camera::flushOutput()
 {
 
-    // Extract and save the time points of all exposures
-    // Note: keyValuePair is (key, value) pair, where key is also a pair consisting of the startTime and StarID
-
+    // Write information about star positions
+ 
     if (writeStarPositions)
-    {
-        if (groupByExposure){hdf5File.writeStarPositionByExposure(detectedStarInfo, beginExposureNr);}
-	else {hdf5File.writeStarPositionByStarID(detectedStarInfo, starIDsInSubfield);}
-    }
-    else
-    {
-        Log.warning("Camera: No star positions written to HDF5 file by user demand (see input file).");
-    }
+      {
+	if (groupByExposure)
+	  {
+	    hdf5File.writeStarPositionByExposure(detectedStarInfo, beginExposureNr);
+	  }
+	else
+	  {
+	    hdf5File.writeStarPositionByStarID(detectedStarInfo, starIDsInSubfield);
+	  }
+      }
 
-
-    // If the ghost option was set, also write for each exposure the info of the ghost stars to the HDF5 file.
+    // Write info of the ghost stars to the HDF5 file
 
     if ((includePointLikeGhosts || includeExtendedGhosts) && writeGhostPositions)
     {

--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -3285,33 +3285,47 @@ void Detector::initHDF5Groups()
 {
     Log.debug("Detector: initialising HDF5 groups");
 
-    hdf5File.createGroup("/Time");
-    hdf5File.createGroup("/Images");
-    hdf5File.createGroup("/BiasMapsLeft");
-    hdf5File.createGroup("/BiasMapsRight");
-    hdf5File.createGroup("/SmearingMaps");
-    hdf5File.createGroup("/Flatfield");
-    hdf5File.createGroup("/ThroughputMaps");
+    //hdf5File.createGroup("/Time");
 
+    if (writePixelMaps)
+      {
+	hdf5File.createGroup("/Images");
+      }
+
+    if (writeBiasMaps)
+      {
+	hdf5File.createGroup("/BiasMapsLeft");
+	hdf5File.createGroup("/BiasMapsRight");
+      }
+    
+    if (writeSmearingMaps)
+      {
+	hdf5File.createGroup("/SmearingMaps");
+      }
+
+    if (writeThroughputMaps)
+      {
+	hdf5File.createGroup("/ThroughputMaps");
+      }
+   
     if (writeBackgroundMap || constantSkyBackground)
-    {
+      {
         hdf5File.createGroup("/BackgroundMap");
-    }    
+      }    
     
     if (writeCTI && (CTImodel == "Short2013"))
-    {
+      {
         hdf5File.createGroup("/CTI");
-    }
+      }
 
     if (writeCosmics)
-    {
+      {
         hdf5File.createGroup("/Cosmics");
         hdf5File.createGroup("/Cosmics/SubField");
         hdf5File.createGroup("/Cosmics/SmearingMap");
         hdf5File.createGroup("/Cosmics/BiasMapLeft");
         hdf5File.createGroup("/Cosmics/BiasMapRight");
-    }
-
+      }
 }
 
 

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -27,9 +27,21 @@
  * \param camera         Camera to which to attach the detector.
  * \param readoutTimeBeforeNextExposure Duration of the readout that takes place before the next exposure can start.
  */
-
-DetectorWithAnalyticNonGaussianPSF::DetectorWithAnalyticNonGaussianPSF(ConfigurationParameters &configParam, HDF5File &hdf5file, Camera &camera, TemperatureGenerator &feeTemperatureGenerator, TemperatureGenerator &detectorTemperatureGenerator, double readoutTimeBeforeNextExposure, double readoutTimeDuringNextExposure)
-: Detector(configParam, hdf5file, camera, feeTemperatureGenerator, detectorTemperatureGenerator, readoutTimeBeforeNextExposure, readoutTimeDuringNextExposure), sigma(nullptr)
+DetectorWithAnalyticNonGaussianPSF::DetectorWithAnalyticNonGaussianPSF(ConfigurationParameters &configParam,
+								       HDF5File &hdf5file,
+								       Camera &camera,
+								       TemperatureGenerator &feeTemperatureGenerator,
+								       TemperatureGenerator &detectorTemperatureGenerator,
+								       double readoutTimeBeforeNextExposure,
+								       double readoutTimeDuringNextExposure)
+: Detector(configParam,
+	   hdf5file,
+	   camera,
+	   feeTemperatureGenerator,
+	   detectorTemperatureGenerator,
+	   readoutTimeBeforeNextExposure,
+	   readoutTimeDuringNextExposure),
+  sigma(nullptr)
 {
     // Parse the parameters from the configuration file.
 
@@ -46,7 +58,7 @@ DetectorWithAnalyticNonGaussianPSF::DetectorWithAnalyticNonGaussianPSF(Configura
       generateFlatfieldMap();
     }
 
-    // Initialize and load the PSF. This will open the PSF HDF5 file and perform some basic checking,
+    // TODO Initialize and load the PSF. This will open the PSF HDF5 file and perform some basic checking,
     // Then select the proper PSF for the given subfield. Should only be done after calling configure().
 }
 
@@ -84,13 +96,15 @@ DetectorWithAnalyticNonGaussianPSF::~DetectorWithAnalyticNonGaussianPSF()
 
 void DetectorWithAnalyticNonGaussianPSF::configure(ConfigurationParameters &configParam)
 {
-    numExposures        = configParam.getUnsignedInteger("ObservingParameters/NumExposures");
-    beginExposureNr     = configParam.getUnsignedInteger("ObservingParameters/BeginExposureNr");
-    cycleTime           = configParam.getDouble("ObservingParameters/CycleTime");
 
-    flatfieldNoiseRMS   = configParam.getDouble("CCD/FlatfieldNoiseRMS");
-    includeFlatfield    = configParam.getBoolean("CCD/IncludeFlatfield");
-    flatfieldSeed       = configParam.getLong("RandomSeeds/FlatFieldSeed");
+    // Fetch configuration information
+  
+    numExposures      = configParam.getUnsignedInteger("ObservingParameters/NumExposures");
+    beginExposureNr   = configParam.getUnsignedInteger("ObservingParameters/BeginExposureNr");
+    cycleTime         = configParam.getDouble("ObservingParameters/CycleTime");
+    flatfieldNoiseRMS = configParam.getDouble("CCD/FlatfieldNoiseRMS");
+    includeFlatfield  = configParam.getBoolean("CCD/IncludeFlatfield");
+    flatfieldSeed     = configParam.getLong("RandomSeeds/FlatFieldSeed");
 
     // Read and configure the parameters used to calculate the PSF
 
@@ -121,11 +135,10 @@ void DetectorWithAnalyticNonGaussianPSF::configure(ConfigurationParameters &conf
 
     // The parameters for the charge diffusion
 
-    includeChargeDiffusion = configParam.getBoolean("PSF/AnalyticNonGaussian/IncludeChargeDiffusion");
+    includeChargeDiffusion  = configParam.getBoolean("PSF/AnalyticNonGaussian/IncludeChargeDiffusion");
     chargeDiffusionStrength = configParam.getDouble("PSF/AnalyticNonGaussian/ChargeDiffusionStrength");
 
     Log.info("DetectorWithAnalyticNonGaussianPSF: sigma of charge diffusion: " + to_string(chargeDiffusionStrength) + " pix");
-
 
     // The sigma of the PSF can either be a fixed value, or given by a time series in a file
 
@@ -145,10 +158,9 @@ void DetectorWithAnalyticNonGaussianPSF::configure(ConfigurationParameters &conf
         Log.info("DetectorWithAnalyticNonGaussianPSF: Reading sigma PSF from " + sigmaPSFInputFile);
     }
 
-
     // The configuration for the on-the-fly photometry
 
-    includePhotometry    = configParam.getBoolean("Photometry/IncludePhotometry");
+    includePhotometry = configParam.getBoolean("Photometry/IncludePhotometry");
 
     if (includePhotometry)
     {
@@ -192,12 +204,11 @@ void DetectorWithAnalyticNonGaussianPSF::configure(ConfigurationParameters &conf
         }
     }
 
-
     // The configuration for the HDF5 contents
 
-    writeFlatfieldMap = configParam.getBoolean("ControlHDF5Content/WriteFlatfieldMap");
+    writeFlatfieldMap      = configParam.getBoolean("ControlHDF5Content/WriteFlatfieldMap");
     writeHighResolutionPSF = configParam.getBoolean("ControlHDF5Content/WriteHighResolutionPSF");
-    writeDiffusedPSF = configParam.getBoolean("ControlHDF5Content/WriteDiffusedPSF");
+    writeDiffusedPSF       = configParam.getBoolean("ControlHDF5Content/WriteDiffusedPSF");
 
 } // end configure()
 
@@ -386,6 +397,7 @@ void DetectorWithAnalyticNonGaussianPSF::generateFlatfieldMap()
     if (writeFlatfieldMap)
     {
         Log.debug("Detector: writing PRNU to HDF5");
+	hdf5File.createGroup("/Flatfield");
         hdf5File.writeArray("/Flatfield", "PRNU", flatfieldMap);
     }
 }
@@ -913,7 +925,10 @@ void DetectorWithAnalyticNonGaussianPSF::flushOutput()
     // Create the group in the HDF5 file.
     // We chose the same name as for DetectorWithMappedPSF
 
-    hdf5File.createGroup("/PSF");
+    if (writeHighResolutionPSF || (writeDiffusedPSF && includeChargeDiffusion))
+      {
+    	hdf5File.createGroup("/PSF");
+      }
 
     // Generate and save the high resolution PSF (center of subfield)
 

--- a/source/DetectorWithMappedPSF.cpp
+++ b/source/DetectorWithMappedPSF.cpp
@@ -27,9 +27,22 @@
  * \param camera         Camera to which to attach the detector.
  * \param readoutTimeBeforeNextExposure Duration of the readout that takes place before the next exposure can start.
  */
-
-DetectorWithMappedPSF::DetectorWithMappedPSF(ConfigurationParameters &configParam, HDF5File &hdf5file, Camera &camera, TemperatureGenerator &feeTemperatureGenerator, TemperatureGenerator &detectorTemperatureGenerator, double readoutTimeBeforeNextExposure, double readoutTimeDuringNextExposure)
-  : Detector(configParam, hdf5file, camera, feeTemperatureGenerator, detectorTemperatureGenerator, readoutTimeBeforeNextExposure, readoutTimeDuringNextExposure), includeFlatfield(true), writeSubPixelImagesToHDF5(false)
+DetectorWithMappedPSF::DetectorWithMappedPSF(ConfigurationParameters &configParam,
+					     HDF5File &hdf5file,
+					     Camera &camera,
+					     TemperatureGenerator &feeTemperatureGenerator,
+					     TemperatureGenerator &detectorTemperatureGenerator,
+					     double readoutTimeBeforeNextExposure,
+					     double readoutTimeDuringNextExposure)
+  : Detector(configParam,
+	     hdf5file,
+	     camera,
+	     feeTemperatureGenerator,
+	     detectorTemperatureGenerator,
+	     readoutTimeBeforeNextExposure,
+	     readoutTimeDuringNextExposure),    
+    includeFlatfield(true),
+    writeSubPixelImagesToHDF5(false)
 {
     // Parse the parameters from the configuration file.
 
@@ -46,18 +59,22 @@ DetectorWithMappedPSF::DetectorWithMappedPSF(ConfigurationParameters &configPara
     subPixelMap.zeros(numRowsSubPixelMap, numColumnsSubPixelMap);
     flatfieldMap.ones(numRowsSubPixelMap, numColumnsSubPixelMap);
 
+    // Initialize the subpixel background map
+    
     if (!constantSkyBackground)
-    {
-        // Initialize the subpixel background map
-        subPixelBackgroundMap.zeros(numRowsSubPixelMap, numColumnsSubPixelMap);
+    { 
+      subPixelBackgroundMap.zeros(numRowsSubPixelMap, numColumnsSubPixelMap);
     }
+    
+    // Allocate memory for undistorted maps
+    
     unDistortedX.zeros(numRowsPixelMap, numColumnsPixelMap);
     unDistortedY.zeros(numRowsPixelMap, numColumnsPixelMap);
 
+    // Generate the flatfield map
+    
     if (includeFlatfield)
     {
-        // Generate the flatfield map
-
         generateFlatfieldMap();
     }
 
@@ -67,6 +84,9 @@ DetectorWithMappedPSF::DetectorWithMappedPSF(ConfigurationParameters &configPara
     psf = new PointSpreadFunction(configParam, hdf5file);
     setPsfForSubfield();
 }
+
+
+
 
 
 
@@ -81,6 +101,10 @@ DetectorWithMappedPSF::~DetectorWithMappedPSF()
 }
 
 
+
+
+
+
 /**
  * \brief Configure the DetectorWithMappedPSF object using the given
  *        configuration parameters.
@@ -89,13 +113,13 @@ DetectorWithMappedPSF::~DetectorWithMappedPSF()
  */
 void DetectorWithMappedPSF::configure(ConfigurationParameters &configParam)
 {
-    flatfieldNoiseRMS = configParam.getDouble("CCD/FlatfieldNoiseRMS");
-    includeFlatfield = configParam.getBoolean("CCD/IncludeFlatfield");
-    includeConvolution = configParam.getBoolean("CCD/IncludeConvolution");
-
+    // General configuration parameters
+  
+    flatfieldNoiseRMS         = configParam.getDouble("CCD/FlatfieldNoiseRMS");
+    includeFlatfield          = configParam.getBoolean("CCD/IncludeFlatfield");
+    includeConvolution        = configParam.getBoolean("CCD/IncludeConvolution");
     writeSubPixelImagesToHDF5 = configParam.getBoolean("ControlHDF5Content/WriteSubPixelImages");
-
-    numSubPixelsPerPixel = configParam.getInteger("SubField/SubPixels");
+    numSubPixelsPerPixel      = configParam.getInteger("SubField/SubPixels");
 
     // Configuration parameters for the noise source random seeds
 
@@ -123,13 +147,13 @@ void DetectorWithMappedPSF::configure(ConfigurationParameters &configParam)
 
     // Derive the dimensions of the sub-pixel map
 
-    numRowsSubPixelMap = numRowsPixelMap * numSubPixelsPerPixel;       // TODO Add edge pixels
+    numRowsSubPixelMap    = numRowsPixelMap    * numSubPixelsPerPixel; // TODO Add edge pixels
     numColumnsSubPixelMap = numColumnsPixelMap * numSubPixelsPerPixel; // TODO Add edge pixels
 
     // The configuration for the HDF5 contents
 
     writeFlatfieldMap = configParam.getBoolean("ControlHDF5Content/WriteFlatfieldMap");
-    writeDiffusedPSF = configParam.getBoolean("ControlHDF5Content/WriteDiffusedPSF");
+    writeDiffusedPSF  = configParam.getBoolean("ControlHDF5Content/WriteDiffusedPSF");
 }
 
 
@@ -207,16 +231,12 @@ void DetectorWithMappedPSF::generateDiffusionKernel(double kernelWidth)
 
 
 
-
-
-
 /**
  * \brief: Generate the (random) flatfield variations.  This map is generated
  *         at sub-pixel level but without the edge pixels.
  *
  * https://github.com/python-acoustics/python-acoustics/blob/master/acoustics/generator.py#L108
  */
-
 void DetectorWithMappedPSF::generateFlatfieldMap()
 {
     Log.info("DetectorWithMappedPSF: generating flatfield map.");
@@ -939,11 +959,16 @@ void DetectorWithMappedPSF::convolveWithPsf()
  */
 void DetectorWithMappedPSF::initHDF5Groups()
 {
-    // Init the groups specific for the MappedPSF detector
-
-    if (writeSubPixelImagesToHDF5)
+  if (writeFlatfieldMap)
     {
-        hdf5File.createGroup("/SubPixelImages");
+      Log.debug("DetectorWithMappedPSF: creating Flatfield entry in HDF5");
+      hdf5File.createGroup("/Flatfield");
+    }
+
+  if (writeSubPixelImagesToHDF5)
+    {
+      Log.debug("DetectorWithMappedPSF: creating SubPixelImages entry in HDF5");
+      hdf5File.createGroup("/SubPixelImages");
     }
 }
 

--- a/source/HDF5File.cpp
+++ b/source/HDF5File.cpp
@@ -2060,6 +2060,22 @@ void HDF5File::writeVersionInformation()
 
 
 
+// /** TODO implement idependent time column!
+//  * \brief: include the tranmsissionEfficiency values to the HDF5 file.
+//  *
+//  */
+// void HDF5File::writeTime(double* array, int size)
+// {
+//     writeArray("Time/", "time", array, size);
+// }
+
+
+
+
+
+
+
+
 
 
 /**
@@ -2164,7 +2180,7 @@ void HDF5File::writeSmearingMap(arma::Mat<float>& smearingMap, bool includeQuant
 void HDF5File::writeTelescopeACS(vector<double>& time, vector<double>& RA, vector<double>& dec,
 				 vector<double>& yaw, vector<double>& pitch, vector<double>& roll)
 {
-    writeArray("/Time/",      "time",           time.data(),    time.size());
+    writeArray("/Telescope/", "time",           time.data(),    time.size());
     writeArray("/Telescope/", "telescopeRA",    RA.data(),      RA.size());         // [deg]
     writeArray("/Telescope/", "telescopeDec",   dec.data(),     dec.size());        // [deg]
     writeArray("/Telescope/", "telescopeYaw",   yaw.data(),     yaw.size());        // [arcsec]
@@ -2186,8 +2202,8 @@ void HDF5File::writeTelescopeACS(vector<double>& time, vector<double>& RA, vecto
 
 /**
  * /brief: save the star positions to the HDF5 file.
- * /Note: This is the old way of doing things!
  *
+ * NOTE: keyValuePair is (key, value) pair, where key is also a pair consisting of the startTime and StarID
  */
 void HDF5File::writeStarPositionByExposure(map<double, map<unsigned int, array<double, 6>>>& detectedStarInfo, int beginExposureNr)
 {
@@ -2196,7 +2212,17 @@ void HDF5File::writeStarPositionByExposure(map<double, map<unsigned int, array<d
 
     vector<double> time;
     for(auto keyValuePair: detectedStarInfo) time.push_back(keyValuePair.first);
-    
+
+    // TODO Remove
+    // if (!time.empty())
+    // {
+    //   writeArray("StarPositions/", "time", time.data(), time.size());
+    // }
+    // else
+    // {
+    //   Log.warning("HDF5File: No star positions to write to HDF5 file.");
+    // }
+
     if (time.empty())
     {
       Log.warning("HDF5File: No star positions to write to HDF5 file.");
@@ -2274,6 +2300,15 @@ void HDF5File::writeStarPositionByStarID(map<double, map<unsigned int, array<dou
     vector<double> time;
     for(auto keyValuePair: detectedStarInfo) time.push_back(keyValuePair.first);
 
+    // if (!time.empty())
+    // {
+    //   writeArray("StarPositions/", "Time", time.data(), time.size());
+    // }
+    // else
+    // {
+    //   Log.warning("HDF5File: No star positions to write to HDF5 file.");
+    // }
+    
     if (time.empty())
     {
       Log.warning("HDF5File: No star positions to write to HDF5 file.");
@@ -2327,6 +2362,7 @@ void HDF5File::writeStarPositionByStarID(map<double, map<unsigned int, array<dou
         myStream << "starID" << setfill('0') << setw(6) << 0 + starIDs[n];
         const string exposureGroupName = "/StarPositions/" + myStream.str();
         createGroup(exposureGroupName);
+        //writeArray(exposureGroupName, "time",   times.data(),   times.size());	
         writeArray(exposureGroupName, "xFPmm",  xFPmm.data(),   xFPmm.size());
         writeArray(exposureGroupName, "yFPmm",  yFPmm.data(),   yFPmm.size());
         writeArray(exposureGroupName, "rowPix", rowPix.data(),  rowPix.size());
@@ -2362,6 +2398,15 @@ void HDF5File::writePointlikeGhostByExposure(map<double, map<unsigned int, array
     createGroup("/PointLikeGhostPositions");
     vector<double> time;
     for(auto keyValuePair: detectedPointLikeGhostInfo) time.push_back(keyValuePair.first);
+
+    // if (!time.empty())
+    // {
+    //     writeArray("PointLikeGhostPositions/", "Time", time.data(), time.size());
+    // }
+    // else
+    // {
+    //     Log.warning("HDF5File: No point-like ghost positions to write to HDF5 file.");
+    // }
     
     if (time.empty())
     {
@@ -2450,6 +2495,15 @@ void HDF5File::writePointlikeGhostByStarID(map<double, map<unsigned int, array<d
     vector<double> time;
     for(auto keyValuePair: detectedPointLikeGhostInfo) time.push_back(keyValuePair.first);
 
+    // if (!time.empty())
+    // {
+    //     writeArray("PointLikeGhostPositions/", "Time", time.data(), time.size());
+    // }
+    // else
+    // {
+    //     Log.warning("HDF5File: No point-like ghost positions to write to HDF5 file.");
+    // }
+    
     if (time.empty())
     {
         Log.warning("HDF5File: No point-like ghost positions to write to HDF5 file.");
@@ -2507,6 +2561,7 @@ void HDF5File::writePointlikeGhostByStarID(map<double, map<unsigned int, array<d
           myStream << "StarID" << setfill('0') << setw(6) << 0 + starIDs[n];
           const string pointLikeGhostGroupName = "/PointLikeGhostPositions/" + myStream.str();
           createGroup(pointLikeGhostGroupName);
+          //writeArray(pointLikeGhostGroupName, "time",   times.data(),   times.size());  
           writeArray(pointLikeGhostGroupName, "xFPmm",  xFPmm.data(),   xFPmm.size());
           writeArray(pointLikeGhostGroupName, "yFPmm",  yFPmm.data(),   yFPmm.size());
           writeArray(pointLikeGhostGroupName, "rowPix", rowPix.data(),  rowPix.size());
@@ -2545,6 +2600,16 @@ void HDF5File::writeExtendedGhostByExposure(map<double, map<unsigned int, array<
   createGroup("/ExtendedGhostPositions");
   vector<double> time;
   for(auto keyValuePair: detectedExtendedGhostInfo) time.push_back(keyValuePair.first);
+
+  // if (!time.empty())
+  // {
+  //   writeArray("ExtendedGhostPositions/", "Time", time.data(), time.size());
+  // }
+  // else
+  // {
+  //   Log.warning("HDF5File: No extended ghost positions to write to HDF5 file.");
+  // }
+  
   if (time.empty())
   {
     Log.warning("HDF5File: No extended ghost positions to write to HDF5 file.");
@@ -2632,6 +2697,15 @@ void HDF5File::writeExtendedGhostByStarID(map<double, map<unsigned int, array<do
   vector<double> time;
   for(auto keyValuePair: detectedExtendedGhostInfo) time.push_back(keyValuePair.first);
 
+  // if (!time.empty())
+  // {
+  //   writeArray("ExtendedGhostPositions/", "Time", time.data(), time.size());
+  // }
+  // else
+  // {
+  //   Log.warning("HDF5File: No extended ghost positions to write to HDF5 file.");
+  // }
+  
   if (time.empty())
   {
     Log.warning("HDF5File: No extended ghost positions to write to HDF5 file.");
@@ -2688,6 +2762,7 @@ void HDF5File::writeExtendedGhostByStarID(map<double, map<unsigned int, array<do
       myStream << "Exposure" << setfill('0') << setw(6) << 0 + starIDs[n];
       const string extendedGhostGroupName = "/ExtendedGhostPositions/" + myStream.str();
       createGroup(extendedGhostGroupName);
+      //writeArray(extendedGhostGroupName, "times",  times.data(),       times.size());      
       writeArray(extendedGhostGroupName, "xFPmm",  xFPmm.data(),       xFPmm.size());
       writeArray(extendedGhostGroupName, "yFPmm",  yFPmm.data(),       yFPmm.size());
       writeArray(extendedGhostGroupName, "rowPix", rowPix.data(),      rowPix.size());

--- a/source/Platform.cpp
+++ b/source/Platform.cpp
@@ -13,17 +13,21 @@
  * 
  * \note  The jitterGenerator has been configured in Simulation::Simulation()
  */
-
-Platform::Platform(ConfigurationParameters configParams, HDF5File &hdf5File, JitterGenerator &jitterGenerator)
-: HDF5Writer(hdf5File), useJitter(true), internalTime(0.0), jitterGenerator(jitterGenerator)
+Platform::Platform(ConfigurationParameters configParams,
+		   HDF5File &hdf5File,
+		   JitterGenerator &jitterGenerator)
+: HDF5Writer(hdf5File),
+  useJitter(true),
+  internalTime(0.0),
+  jitterGenerator(jitterGenerator)
 {
-    // Initialise the HDF5 group(s) in the output file
-
-    initHDF5Groups();
-
     // Configure the Platfrom object
 
     configure(configParams);
+
+    // Initialise the HDF5 group(s) in the output file
+
+    initHDF5Groups();
 
     // Initialise the rotation matrices (should be done after configuration) with the unjittered spacecraft
 
@@ -64,32 +68,38 @@ Platform::~Platform()
 
 void Platform::configure(ConfigurationParameters &configParams)
 {
-    useJitter = configParams.getBoolean("Platform/UseJitter");
+  // General configuration parameters
+  
+  useJitter = configParams.getBoolean("Platform/UseJitter");
+  writeACS  = configParams.getBoolean("ControlHDF5Content/WriteACS");
+  platformOrientationSource = configParams.getString("Platform/Orientation/Source");
 
-    platformOrientationSource = configParams.getString("Platform/Orientation/Source");
-    if (platformOrientationSource == "Angles") {
-        Log.info("Platform: using the (RA, Dec, Kappa) angles to determine the initial platform orientation");
-        originalRA  = deg2rad(configParams.getDouble("Platform/Orientation/Angles/RAPointing"));            
-        originalDec = deg2rad(configParams.getDouble("Platform/Orientation/Angles/DecPointing"));
-        originalKappa = deg2rad(configParams.getDouble("Platform/Orientation/Angles/SolarPanelOrientation"));
-        currentRA   = originalRA;
-        currentDec  = originalDec;
-        Log.debug("Platform: (RA, Dec, Kappa) = (" + to_string(rad2deg(originalRA)) + " deg, " + to_string(rad2deg(originalDec)) + " deg, " + to_string(rad2deg(originalKappa)) + " deg)");
+  // Select method of platform pointing
+  
+  if (platformOrientationSource == "Angles")
+    {
+      Log.info("Platform: using the (RA, Dec, Kappa) angles to determine the initial platform orientation");
+      originalRA  = deg2rad(configParams.getDouble("Platform/Orientation/Angles/RAPointing"));            
+      originalDec = deg2rad(configParams.getDouble("Platform/Orientation/Angles/DecPointing"));
+      originalKappa = deg2rad(configParams.getDouble("Platform/Orientation/Angles/SolarPanelOrientation"));
+      currentRA   = originalRA;
+      currentDec  = originalDec;
+      Log.debug("Platform: (RA, Dec, Kappa) = (" + to_string(rad2deg(originalRA)) + " deg, " + to_string(rad2deg(originalDec)) + " deg, " + to_string(rad2deg(originalKappa)) + " deg)");
     }
-    else if (platformOrientationSource == "Quaternion") {
-        Log.info("Platform: using the Platform/Orientation/Quaternion to determine the initial platform orientation");
-        vector<double> quaternion = configParams.getDoubleVector("Platform/Orientation/Quaternion/Components");
-        copy(quaternion.begin(), quaternion.end(), original_q_EQ2PLM.begin());
-        tie(originalRA, originalDec) = calculatePlatFormSkyCoordinatesFromQuaternion(original_q_EQ2PLM);         // [rad]
-        currentRA  = originalRA;                                                                                 // [rad]
-        currentDec = originalDec;                                                                                // [rad]
-        Log.debug("Platform: (RA, Dec) from quaternion = (" + to_string(rad2deg(originalRA)) + " deg, " + to_string(rad2deg(originalDec)) + " deg)");
+  else if (platformOrientationSource == "Quaternion")
+    {
+      Log.info("Platform: using the Platform/Orientation/Quaternion to determine the initial platform orientation");
+      vector<double> quaternion = configParams.getDoubleVector("Platform/Orientation/Quaternion/Components");
+      copy(quaternion.begin(), quaternion.end(), original_q_EQ2PLM.begin());
+      tie(originalRA, originalDec) = calculatePlatFormSkyCoordinatesFromQuaternion(original_q_EQ2PLM);         // [rad]
+      currentRA  = originalRA;                                                                                 // [rad]
+      currentDec = originalDec;                                                                                // [rad]
+      Log.debug("Platform: (RA, Dec) from quaternion = (" + to_string(rad2deg(originalRA)) + " deg, " + to_string(rad2deg(originalDec)) + " deg)");
     }
-    else {
-        Log.error("In input yaml file: unsupported Platform/Orientation/Source value. Only Angles or Quaternion are allowed");
+  else
+    {
+      Log.error("In input yaml file: unsupported Platform/Orientation/Source value. Only Angles or Quaternion are allowed");
     }
-
-    writeACS    = configParams.getBoolean("ControlHDF5Content/WriteACS");
 }
 
 
@@ -110,9 +120,11 @@ void Platform::configure(ConfigurationParameters &configParams)
 
 void Platform::initHDF5Groups()
 {
-    Log.debug("Platform: initialising HDF5 groups");
-
-    hdf5File.createGroup("/ACS");
+  if (writeACS)
+    {
+      Log.debug("Platform: initialising HDF5 group: ACS");
+      hdf5File.createGroup("/ACS");
+    }
 }
 
 
@@ -128,32 +140,30 @@ void Platform::initHDF5Groups()
 /**
  * \brief Write all recorded information to the HDF5 output file
  */
-
 void Platform::flushOutput()
 {
-    if (writeACS)
+  if (writeACS)
     {
-        Log.info("Platform: Flushing output to HDf5 file.");
+      Log.info("Platform: Flushing output to HDf5 file.");
 
-        if ( ! hdf5File.hasGroup("ACS") )
+      if (!hdf5File.hasGroup("/ACS"))
         {
-            Log.warning("Platform.flushOutput: HDF5 file has no ACS group, cannot flush Platform information.");
-            return;
+	  Log.warning("Platform.flushOutput: HDF5 file has no ACS group, cannot flush Platform information.");
+	  return;
         }
-        
 
-        if (!historyTime.empty())
+      if (!historyTime.empty())
         {
-	  //hdf5File.writeArray("/ACS/", "Time",        historyTime.data(),  historyTime.size());
-           hdf5File.writeArray("/ACS/", "platformRA",  historyRA.data(),    historyRA.size());
-           hdf5File.writeArray("/ACS/", "platformDec", historyDec.data(),   historyDec.size());
-           hdf5File.writeArray("/ACS/", "yaw",         historyYaw.data(),   historyYaw.size());
-           hdf5File.writeArray("/ACS/", "pitch",       historyPitch.data(), historyPitch.size());
-           hdf5File.writeArray("/ACS/", "roll",        historyRoll.data(),  historyRoll.size());
+	  hdf5File.writeArray("/ACS", "time",        historyTime.data(),  historyTime.size());
+	  hdf5File.writeArray("/ACS", "platformRA",  historyRA.data(),    historyRA.size());
+	  hdf5File.writeArray("/ACS", "platformDec", historyDec.data(),   historyDec.size());
+	  hdf5File.writeArray("/ACS", "yaw",         historyYaw.data(),   historyYaw.size());
+	  hdf5File.writeArray("/ACS", "pitch",       historyPitch.data(), historyPitch.size());
+	  hdf5File.writeArray("/ACS", "roll",        historyRoll.data(),  historyRoll.size());
         }
-        else
+      else
         {
-           Log.warning("Platform: No ACS history to flush to HDF5 file.");
+	  Log.warning("Platform: No ACS history to flush to HDF5 file.");
         }
     }
 }

--- a/source/PointSpreadFunction.cpp
+++ b/source/PointSpreadFunction.cpp
@@ -28,26 +28,23 @@
  * The flatfieldMap is filled at sub-pixel level, the throughputMap and cteMap are filled at pixel level.
  *
  * \param configParam: Configuration parameters for the detector.
- *
  * \param hdf5file:HFD5 file to write the detector images to.
- *
  * \param camera: Camera to which to attach the detector.
- *
  * \param readoutTimeBeforeNextExposure Duration of the readout that takes place before the next exposure can start [s].
  */
 PointSpreadFunction::PointSpreadFunction(ConfigurationParameters &configParam, HDF5File &hdf5file) : HDF5Writer(hdf5file)
 {
-    // Create the groups in the HDF5 file where the different PSFs and their description will be saved.
-
-    initHDF5Groups();
-
     // Parse the parameters from the configuration file.
 
     configure(configParam);
 
     isSelected = false;
-    isRotated = false;
+    isRotated  = false;
 
+    // Create the groups in the HDF5 file where the different PSFs and their description will be saved.
+
+    initHDF5Groups();
+    
     // Prepare the psfFile by performing some basic checks
 
     if (!FileUtilities::fileExists(absolutePath))
@@ -103,9 +100,11 @@ void PointSpreadFunction::configure(ConfigurationParameters &configParam)
         // The number of sub-pixels per pixel is derived from the number of pixels specified
         // and the size of the array in the file. (The number of sub-pixels should be in the file).
 
-        absolutePath = configParam.getAbsoluteFilename("PSF/MappedFromFile/Filename");
-        numberOfPixels = configParam.getInteger("PSF/MappedFromFile/NumberOfPixels");
+        absolutePath           = configParam.getAbsoluteFilename("PSF/MappedFromFile/Filename");
+        numberOfPixels         = configParam.getInteger("PSF/MappedFromFile/NumberOfPixels");
+	includeChargeDiffusion = configParam.getBoolean("PSF/MappedFromFile/IncludeChargeDiffusion");
 	writeHighResolutionPSF = configParam.getBoolean("ControlHDF5Content/WriteHighResolutionPSF");
+	writeDiffusedPSF       = configParam.getBoolean("ControlHDF5Content/WriteDiffusedPSF");
     }
     else
     {
@@ -131,15 +130,17 @@ void PointSpreadFunction::configure(ConfigurationParameters &configParam)
 
 
 
-/**
+/**'
  * \brief Creates the group(s) in the HDF5 file where the PSF information will be stored.
  *        These group(s) has (have) to be created once, at the very beginning.
  */
 void PointSpreadFunction::initHDF5Groups()
 {
-    Log.debug("PointSpreadFunction: initialising HDF5 groups");
-
-    hdf5File.createGroup("/PSF");
+  if (writeHighResolutionPSF || (writeDiffusedPSF && includeChargeDiffusion))
+    {
+      Log.debug("PointSpreadFunction: initialising HDF5 groups");
+      hdf5File.createGroup("/PSF");
+    }  
 }
 
 
@@ -158,7 +159,10 @@ void PointSpreadFunction::flushOutput()
 
     // Save the PSF subpixel map when it is rebinned to pixel level.
 
-    rebinToPixels();
+    if (writeHighResolutionPSF || (writeDiffusedPSF && includeChargeDiffusion))
+      {
+	rebinToPixels();
+      }
 }
 
 
@@ -219,8 +223,6 @@ void PointSpreadFunction::select(double xFP, double yFP)
 
     psfFile.readArray("/", selectedDatasetName, psfMap);
 
-
-
     rotationAngle = 0.0;
 
     // We should be able to read the number of sub-pixels per pixel that was used to generate the PSFs
@@ -230,10 +232,12 @@ void PointSpreadFunction::select(double xFP, double yFP)
 
     numberOfSubPixelsPerPixel = psfMap.n_rows / numberOfPixels;
 
-    hdf5File.writeAttribute("/PSF", "selectedPSF", "Realistic PSF selected from dataset " + datasetName + ".");
-
+    if (writeHighResolutionPSF || (writeDiffusedPSF && includeChargeDiffusion))
+      {
+	hdf5File.writeAttribute("/PSF", "selectedPSF", "Realistic PSF selected from dataset " + datasetName + ".");
+      }
+    
     isSelected = true;
-
     initializeDistortionMap();
 }
 
@@ -270,10 +274,11 @@ void PointSpreadFunction::rotate(double angle)
         Log.debug("PointSpreadFunction: rotated current PSF over angle " + to_string(rad2deg(angle)) + " deg");
 
         // Write the psfMap of the rotated PSF to the HDF5 output file
+	
 	if (writeHighResolutionPSF)
 	{
-        hdf5File.writeArray("/PSF", "highResPSF", psfMap);
-        hdf5File.writeAttribute("/PSF", "rotationAngle", rotationAngle);
+	  hdf5File.writeArray("/PSF", "highResPSF", psfMap);
+	  hdf5File.writeAttribute("/PSF", "rotationAngle", rotationAngle);
 	}
     }
 }
@@ -290,16 +295,16 @@ void PointSpreadFunction::rotate(double angle)
 arma::fmat PointSpreadFunction::rebinToPixels()
 {
     unsigned int binSize = psfMap.n_rows / numberOfSubPixelsPerPixel;
-
     arma::fmat rebinnedMap = ArrayOperations::rebin(psfMap, binSize, binSize);
-
     isRebinned = true;
-
     rebinnedMap /= arma::accu(rebinnedMap);
 
     // Write the rebinned PSF to the output HDF5 file
 
-    hdf5File.writeArray("/PSF", "rebinnedPSFpixel", rebinnedMap);
+    if (writeHighResolutionPSF || (writeDiffusedPSF && includeChargeDiffusion))
+      {
+	hdf5File.writeArray("/PSF", "rebinnedPSFpixel", rebinnedMap);
+      }
 
     return rebinnedMap;
 }
@@ -334,7 +339,10 @@ arma::fmat PointSpreadFunction::rebinToSubPixels(unsigned int targetSubPixels)
 
     // Write the rebinned PSF to the output HDF5 file
 
-    hdf5File.writeArray("/PSF", "rebinnedPSFsubPixel", rebinnedMap);
+    if (writeHighResolutionPSF || (writeDiffusedPSF && includeChargeDiffusion))
+      {
+	hdf5File.writeArray("/PSF", "rebinnedPSFsubPixel", rebinnedMap);
+      }
 
     return rebinnedMap;
 }

--- a/tests/validationTests/scripts/Jitter/jitterOnCCDs.py
+++ b/tests/validationTests/scripts/Jitter/jitterOnCCDs.py
@@ -59,7 +59,7 @@ class JitterOnCCDs(Test):
 
             # Get the jitter from the simulation
             simFile = self.sim.run(removeOutputFile = True)
-            yaw, pitch, roll, time = simFile.getYawPitchRoll(True)
+            time, yaw, pitch, roll = simFile.getPlatformYawPitchRoll(getTime=True)
             self.jitter[CCD] = [time, yaw, pitch, roll]
 
 

--- a/tests/validationTests/scripts/Jitter/jitterOnCameras.py
+++ b/tests/validationTests/scripts/Jitter/jitterOnCameras.py
@@ -53,7 +53,7 @@ class JitterOnCameras(Test):
 
             # Get the jitter from the simulation
             simFile = self.sim.run(removeOutputFile = True)
-            yaw, pitch, roll, time = simFile.getYawPitchRoll(True)
+            time, yaw, pitch, roll = simFile.getPlatformYawPitchRoll(getTime=True)
             self.jitter[camera] = [time, yaw, pitch, roll]
 
 

--- a/tests/validationTests/scripts/ThermoElasticDrift/tedOnCCDs.py
+++ b/tests/validationTests/scripts/ThermoElasticDrift/tedOnCCDs.py
@@ -54,7 +54,7 @@ class TedOnCCDs(Test):
 
             # Get the jitter from the simulation
             simFile = self.sim.run(removeOutputFile = True)
-            yaw, pitch, roll, time = simFile.getYawPitchRollFromDrift(True)
+            time, yaw, pitch, roll = simFile.getTelescopeYawPitchRoll(getTime=True)
             self.drift[CCD] = [time, yaw, pitch, roll]
 
 

--- a/tests/validationTests/scripts/ThroughputEfficiency/transmissionEfficiency.py
+++ b/tests/validationTests/scripts/ThroughputEfficiency/transmissionEfficiency.py
@@ -58,7 +58,8 @@ class TransmissionEfficiency(Test):
             image  = simFile.getImage(exposure)
 
             hfile = h5py.File(self.outputDir + "/test" + self.nr + ".hdf5", 'r')
-            t = h5.h5get(hfile, "Time/time", verbose = False)
+            #t = h5.h5get(hfile, "Time/time", verbose = False)
+            t = simFile.getTime()
             time = np.append(time, t)
             flux = np.append(flux, image[0][0])
 
@@ -79,7 +80,6 @@ class TransmissionEfficiency(Test):
         tmeBOL   = self.sim["Telescope/TransmissionEfficiency/BOL"]
         tmeEOL   = self.sim["Telescope/TransmissionEfficiency/EOL"]
         endTime  = self.years
-
         tmePlato = self.flux / self.flux[0] * tmeBOL
         tmeTheo  = tmeBOL + self.time * (tmeEOL - tmeBOL) / endTime
         RMS      = np.sqrt(np.sum((1 / len(tmePlato)) * (tmePlato - tmeTheo)**2))


### PR DESCRIPTION
This update include the following changes to the c++ code:
- Restoring the time column for ACS
- Restoring the time column for Telescope
- If the user request not to include a specific group, the group will now not be created and added to the HDF5 output file. This makes the output file much more transparent w.r.t. the user's request.
- The time column of `StarPositions`, `PointLikeGhost`, and `ExtendedGhost` since they are identical. Instead we need to add a single time column that follows the cadence of the observation, including the CCD time offsets. The time column is now generated directly from the information that is provided in the `InputParameters` group of the HDF5 file. This is handled by the `SimFile.getTime()` function currently.

For the python scripts the following have been changed:
- A bugfix to the `lightcurve.plot_detrend()` was fixed
- Added new functions to the `SimFile` class to retrieve information from the `ACS` and `Telescope` group
- Where applicable in the `simfile.py`, it is now possible to add the above mentioned time column to the different function using the flag `getTime=True`
- Where applicable in `simfile.py`, it is now possible to save the requested information into a Pandas data frame using the flag `df=True`. By default each function return numpy arrays. 