### PR TITLE
Solves issue #306. New script to create PLATO FoV catalogues

### DIFF
--- a/python/platosim/platonium/vizier.py
+++ b/python/platosim/platonium/vizier.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
 """
+This script creates a coherent PLATO catalogue that covers the
+FoV of each camera group. It uses the Gaia DR3 catalogue and
+makes query of 9 grid points distribution around the requested
+PLATO pointing field. The output catalogues (one for each group)
+is to be used directly by "platonium", either for the generation
+of full-frame CCD images or for exploitation of the PLATO-CS.
 """
 
 # Python standard
@@ -34,7 +40,7 @@ latex()
 #==============================================================#
 
 
-class StarQuery(object):
+class Vizier(object):
 
     """Class to generate a Gaia DR3 catalogue.
     
@@ -50,12 +56,13 @@ class StarQuery(object):
         self.maglim  = args.maglim
         self.plot    = args.plot
         self.verbose = args.verbose
+        self.bright  = args.bright
 
         if not self.field:
             self.field = 'LOPS2'
             
         if not self.maglim:
-            self.maglim = 17
+            self.maglim = 21
 
         # Output directory
         if args.outdir:
@@ -177,10 +184,14 @@ class StarQuery(object):
 
         df = df.drop(columns='dist')
 
-        # Rename ID column
+        # Rename columns
 
         df = df.rename(columns={'designation': 'gaiaDR3',
-                                'phot_g_mean_mag': 'mag'})
+                                'phot_g_mean_mag': 'mag',
+                                'parallax': 'plx',
+                                'parallax_error': 'plxe',
+                                'teff_gspphot': 'teff',
+                                'logg_gspphot': 'logg'})
 
         # Keep digit ID only
 
@@ -188,10 +199,10 @@ class StarQuery(object):
 
         # Add brightest stars not available in Gaia
 
-        if self.field == 'LOPS':
-            sirius  = {'gaiaDR3':'Sirius',  'ra': 101.2871667, 'dec': -16.7161167, 'mag': -1.46}
-            canopus = {'gaiaDR3':'Canopus', 'ra':  95.9879167, 'dec': -52.6956611, 'mag': -0.72}
-            epscma  = {'gaiaDR3':'epsCMa',  'ra': 104.6564583, 'dec': -28.9720861, 'mag':  1.50}
+        if self.bright:
+            sirius  = {'gaiaDR3':'Sirius',  'ra':101.2871667, 'dec':-16.7161167, 'mag':-1.46}
+            canopus = {'gaiaDR3':'Canopus', 'ra': 95.9879167, 'dec':-52.6956611, 'mag':-0.72}
+            epscma  = {'gaiaDR3':'epsCMa',  'ra':104.6564583, 'dec':-28.9720861, 'mag': 1.50}
             df = df.append([sirius, canopus, epscma], ignore_index=True)
 
         # Keep only stars within the camera group FOV
@@ -294,21 +305,22 @@ class StarQuery(object):
 
 parser = argparse.ArgumentParser(epilog=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter,
-                                 description=errorcode('software', '\nStar Query'))
+                                 description=errorcode('software', '\nPLATO FoV Catalogue Query'))
 
 out_group = parser.add_argument_group('I/O PARAMETERS')
-out_group.add_argument('-p', '--plot',    action='store_true', help='Flag for plotting')
-out_group.add_argument('-v', '--verbose', action='store_true', help='Flag for verbosity')
-out_group.add_argument('-o', '--outdir', metavar='PATH', type=str, help='Output directory')
-out_group.add_argument('--project',      metavar='NAME', type=str, help='PLATOnium project')
+out_group.add_argument('-p', '--plot',    action='store_true',      help='Flag for plotting')
+out_group.add_argument('-v', '--verbose', action='store_true',      help='Flag for verbosity')
+out_group.add_argument('-o', '--outdir',  metavar='PATH', type=str, help='Output directory')
+out_group.add_argument('--project',       metavar='NAME', type=str, help='PLATOnium project (overwrites --odir)')
 
 que_group = parser.add_argument_group('QUERY PARAMETERS')
 que_group.add_argument('--field',  metavar='NAME', type=str,   help='LOP (SPF, NPF, LOPS2, LOPN)')
 que_group.add_argument('--maglim', metavar='MAG',  type=float, help='Maximum magnitude to query (default: 17)')
+que_group.add_argument('--bright', action='store_true',        help='Flag add Yale bright stars catalogue')
 
 
 # Initialize instance of class
 args = parser.parse_args()
-x = StarQuery(args)
+x = Vizier(args)
 x.queryGaiaDR3()
 print('')

--- a/python/platosim/slurm.py
+++ b/python/platosim/slurm.py
@@ -218,7 +218,7 @@ def convertWorkerLog(workerLog):
     month_convert = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6, 
                      'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
-    df = pd.read_csv(workerLog, sep='\s+|\t+|\s+\t+|\t+\s+', engine='python'
+    df = pd.read_csv(workerLog, sep='\s+|\t+|\s+\t+|\t+\s+', engine='python',
                      names=['state', 'a', 'core', 'b', 'c',
                             'month', 'date', 'time', 'year'])
     df = df.drop(['a', 'b', 'c'], axis=1)

--- a/python/platosim/slurm.py
+++ b/python/platosim/slurm.py
@@ -105,42 +105,50 @@ def getJobScript(ids, groups, cameras, quarters,
 
     script = \
     f"""
-    #!/bin/bash
+    #!/bin/bash -l
 
-    #SBATCH -A <account>           # Account name of cluster (mandatory)
-    #SBATCH -o <stdout>            # Name of standard output
-    #SBATCH -e <stderr>            # Name of standard errors
-    #SBATCH -M <cluster>           # Cluster name (VSC: genius or wice)
-    #SBATCH -p <software>          # Cluster software (VSC: batch_debug,batch,bigmen,etc).
-    #SBATCH --nodes={nodes}             # Number of nodes
-    #SBATCH --ntasks-per-node={cores}   # Number of CPU per node
-    #SBATCH --mem-per-cpu={memSim}M     # Amount of RAM memory per CPU
-    #SBATCH -t {walltime}          # Totoal execution of slurm job 
+    #SBATCH -A <account>               # Account name of cluster (mandatory)
+    #SBATCH --mail-user=<email>        # User email
+    #SBATCH --mail-type=END            # Get notified by email if script ends successfuly
+    #SBATCH --mail-type=FAIL           # Get notified by email if script fails
+    #SBATCH -o <stdout>                # Name of standard output
+    #SBATCH -e <stderr>                # Name of standard errors
+    #SBATCH -M <cluster>               # Cluster name (VSC: genius or wice)
+    #SBATCH -p <partition>             # Cluster software (VSC: batch_debug,batch,bigmen,etc).
+    #SBATCH --nodes={nodes}            # Number of nodes
+    #SBATCH --ntasks-per-node={cores}  # Number of CPU per node
+    #SBATCH --mem-per-cpu={memSim}M    # Amount of RAM memory per CPU
+    #SBATCH -t {walltime}              # Totoal execution of slurm job 
 
     cd $SLURM_SUBMIT_DIR
-    module purge
-    module restore <name>      # Name of cluster env with modules 
+    module purge                       # Pruge and refresh modules
+    module restore <module_env>        # Name of cluster module environment
 
     # User defined parameters
-    WORKDIR=<workdir_name>     # PLATOnium working directory
-    PROJECT=<project_name>     # PLATOnium project name
+    WORKDIR=<workdir_name>             # PLATOnium working directory
+    PROJECT=<project_name>             # PLATOnium project directory
+    SIMDIR=<storage_name>              # Directory to store output
+    starID=$(printf "%09d" $id)        # 9-digit star ID to include varsource
 
     # Export paths
-    export PLATO=$VSC_DATA/plato
-    export PLATO_PROJECT_HOME=$VSC_DATA/PlatoSim3
-    export PLATO_WORKDIR=$VSC_DATA/$WORKDIR
     export TEMDIR=$VSC_SCRATCH_NODE
-    export OUTDIR=$VSC_SCRATCH/platosim/$PROJECT
+    export VARDIR=$VSC_SCRATCH/platosim/$PROJECT/varsource
+    export OUTDIR=$VSC_SCRATCH/platosim/$PROJECT/$SIMDIR/$starID
+    export PLATO=$VSC_DATA/plato
+    export PLATO_WORKDIR=$VSC_DATA/$WORKDIR
+    export PLATO_PROJECT_HOME=$VSC_DATA/PlatoSim3
     export PYTHONPATH=$PLATO:$PLATO_PROJECT_HOME/python
     export PLATONIUM=$PLATO_PROJECT_HOME/python/platosim/platonium/platonium.py
-    export CONDA=/data/leuven/341/vsc34166/miniconda3/etc/profile.d/conda.sh
+    export PATH=$VSC_DATA/miniconda3/bin:$PATH    
 
     # Activate environment
-    source $CONDA
-    conda activate platonium
+    source activate platonium
+
+    # Secure only 1 thread/cpu
+    export OMP_NUM_THREADS=1
 
     # Run PLATOnium
-    python $PLATONIUM $ids $group $camera $quarter --project $PROJECT -o $TEMDIR -d $OUTDIR --compress
+    python $PLATONIUM $id $group $camera $quarter --project $PROJECT -o $TEMDIR -d $OUTDIR --varfile $VARDIR/varsource_${starID}.txt --compress -v 0 -w
     """
 
     # Save textfile for worker

--- a/python/platosim/starquery.py
+++ b/python/platosim/starquery.py
@@ -267,7 +267,7 @@ def starQuery(star, radius=45):
 
 
 
-def gaiaRegionQuery(ra, dec, radius=19, maglim=17, ofile=False):
+def gaiaRegionQuery(ra, dec, radius=19, maglim=21, ofile=False):
 
     """Function to query a circular sky region from Gaia DR3.
     
@@ -331,23 +331,25 @@ v        File name (without file extension) to be saved
     # Create job to be parsed
     
     params = urllib.urlencode({\
-                               "REQUEST"        : "doQuery",
-                               "LANG"           : "ADQL",
-                               "FORMAT"         : "votable_plain",
-                               "PHASE"          : "RUN",
-                               "JOBNAME"        : "PLATO catalog",
-                               "JOBDESCRIPTION" : "Masterarbeit S. Bowling (contact juan.cabrera@dlr.de)", 
-                               "QUERY"          : f"SELECT DISTANCE(POINT({coord.ra.deg},{coord.dec.deg}), " +
-                                                   "POINT(ra,dec)) " +
-                                                   "AS dist, designation, ra, dec, " +
-                                                   "parallax, parallax_error, pmra, pmdec, ruwe, " +
-                                                   "phot_g_mean_mag, bp_rp " +
-                                                   "teff_gspphot, logg_gspphot, " + 
-                                                  f"FROM {catalogue} AS cat " +
-                                                  f"WHERE 1=CONTAINS(POINT({coord.ra.deg},{coord.dec.deg}), " +
-                                                  f"CIRCLE(cat.ra,cat.dec,{radius})) " +
-                                                  f"AND cat.phot_g_mean_mag < {maglim} ORDER BY dist ASC"})
+            "REQUEST"        : "doQuery",
+            "LANG"           : "ADQL",
+            "FORMAT"         : "votable_plain",
+            "PHASE"          : "RUN",
+            "JOBNAME"        : "PLATO catalog",
+            "JOBDESCRIPTION" : "Masterarbeit S. Bowling (contact juan.cabrera@dlr.de)", 
+            "QUERY"          : f"SELECT DISTANCE(POINT({coord.ra.deg},{coord.dec.deg}), " +
+                               "POINT(ra,dec)) " +
+                               "AS dist, designation, ra, dec, " +
+                               "parallax, parallax_error, " +
+                               "pmra, pmdec, ruwe, " +
+                               "phot_g_mean_mag, bp_rp, " +
+                               "teff_gspphot, logg_gspphot " +
+                               f"FROM {catalogue} AS cat " +
+                               f"WHERE 1=CONTAINS(POINT({coord.ra.deg},{coord.dec.deg}), " +
+                               f"CIRCLE(cat.ra,cat.dec,{radius})) " +
+                               f"AND cat.phot_g_mean_mag < {maglim} ORDER BY dist ASC"})
 
+    
     headers = {"Content-type": "application/x-www-form-urlencoded",
                "Accept"      : "text/plain"}
 


### PR DESCRIPTION
This partly solves issue #306. 

The problem has partly been solved, however, the user should obviously not import an arbitrarily big star catalogue(!). With that said, the PlatoSim toolkit called PLATOnium has now solved this problem for the user in two ways:
1. If the suer wants to simulate stars from the PIC (i.e. NPF/SPF from PIC 1.1.0 or LOPN/LOPS2 form the PIC 2.0.0) these catalogues do not include any stars outside the PLATO FOV. These catalogue can be generated (within tens of minutes) using the PLATOnium script called `picsim`. This function is explained on our documentation page. 
2. If the user want to simulate spectral types different from F5-K7 dwarf/subdwarf stars, then one will typically download a certain sky region from the Gaia (DR3) catalogue. To help producing full-frame images (and to explore the PLATO-CS) we have now implemented the script called ` As part of the PlatoSim toolkit PLATOnium is `vizier.py`