### PR TITLE
Bugfix of missing pyarrow package for platonium toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "platosim"
-version = "3.5.4"
+version = "3.6.0"
 description = "PlatoSim: A end-to-end PLATO camera simulator"
 authors = ["KU Leuven and the PlatoSim team <nicholas.jannsen@kuleuven.be>"]
 readme = "README.md"
@@ -49,6 +49,7 @@ transitleastsquares = "^1.0.31"
 PyAstronomy = "^0.17.1"
 statsmodels = "^0.13.5"
 "ligo.skymap" = "^0.6.1"
+pyarrow = "^7.0.0"
 
 [tool.poetry.group.pipeline]
 optional = true
@@ -59,7 +60,6 @@ numba = "^0.56.4"
 llvmlite = "0.39.1"
 mpi4py = "^3.1.3"
 PyQt5 = "^5.15.6"
-pyarrow = "^7.0.0"
 #PyMT64 = "^1.9"
 
 [tool.poetry.dev-dependencies]

--- a/python/platosim/platonium/platonium
+++ b/python/platosim/platonium/platonium
@@ -555,7 +555,7 @@ class PLATOnium(object):
                                                                                     pathToPsfFile, focalLength)
             else: 
                 xFPmm, yFPmm = rf.undistortedToDistortedFocalPlaneCoordinates(xFPmm, yFPmm,
-                                                                              distortionCoefficients)
+                                                                              distortionCoefficients, focalLength)
 
                 
         # Fetch CCD code and pixel coordinates (account for field distortion if included)

--- a/python/platosim/referenceFrames.py
+++ b/python/platosim/referenceFrames.py
@@ -1611,10 +1611,12 @@ def getCCDandPixelCoordinates(raStar, decStar, raPlatform, decPlatform, solarPan
     if (includeFieldDistortion == True) or (includeFieldDistortion == "yes"):
         if mappedDistortion:
             xFPmm, yFPmm = mappedUndistortedToDistortedFocalPlaneCoordinates(xFPmm, yFPmm,
-                                                                             pathToPsfFile, focalLength)
+                                                                             pathToPsfFile,
+                                                                             focalLength)
         else:
             xFPmm, yFPmm = undistortedToDistortedFocalPlaneCoordinates(xFPmm, yFPmm,
-                                                                       distortionCoefficients)
+                                                                       distortionCoefficients,
+                                                                       focalLength)
 
     # Find out if this falls on a CCD, and if yes which one.
     # Our approach: try each of the CCDs. Not elegant, but robust!


### PR DESCRIPTION
The missing `pyarrow` package was added to `pyproject.toml` to solve an issue of saving feather files using the platonium toolkit.