### PR TITLE
Fixed missing return value

### DIFF
--- a/source/ClosedLoopDetectorClasses.cpp
+++ b/source/ClosedLoopDetectorClasses.cpp
@@ -159,7 +159,7 @@ double ClosedLoopDetectorWithAnalyticNonGaussianPSF::takeExposure(int exposureNr
     }
 
 
-    DetectorWithAnalyticNonGaussianPSF::takeExposure(exposureNr, startTime, exposureTime);
+    return DetectorWithAnalyticNonGaussianPSF::takeExposure(exposureNr, startTime, exposureTime);
 }
 
 


### PR DESCRIPTION
The missing return value caused (online) platosim to crash when compiled with certain gcc versions.