### PR TITLE
Implementation of the Stellar Pollution Ratio (SPR) 

### DIFF
--- a/include/DetectorWithAnalyticNonGaussianPSF.h
+++ b/include/DetectorWithAnalyticNonGaussianPSF.h
@@ -83,8 +83,9 @@ class DetectorWithAnalyticNonGaussianPSF: public Detector
         map<unsigned int, vector<unsigned int>> maskSizeTarget;           // Nr of pixels within the mask for each target
         map<unsigned int, vector<double>> inputFluxTarget;                // Flux of the target as computed from the (variable) Vmag
         map<unsigned int, vector<double>> estimatedFluxTarget;            // Estimated flux for each target
-        map<unsigned int, vector<double>> varFluxTarget;                  //  Variance of the flux for each target
+        map<unsigned int, vector<double>> varFluxTarget;                  // Variance of the flux for each target
         map<unsigned int, vector<double>> NSRtarget;                      // Noise/Signal ratio of the flux of each target
+        map<unsigned int, vector<double>> aggregatedSPR;                  // Stellar pollution ratio = aggregated contaminant flux / aggregated total flux 
     
         // The indices of the masks are stored as [starID][exposureNr][index]
   

--- a/python/platosim/simfile.py
+++ b/python/platosim/simfile.py
@@ -1848,6 +1848,14 @@ class SimFile (object):
         exposureNr : ndarray
             The image number in which the mask was derived:
             exposureNr <= imageNr
+        maskSize: ndarray
+            The number of pixels a mask contains 
+        maskNSR: ndarray 
+            The Noise-to-Signal ratio of the flux. Noise coming from target + contaminants + sky + instrument.
+            Signal coming from the target.
+        maskSPR: ndarray 
+            Stellar pollution ratio. The ratio of the flux inside the mask coming from contaminants and the
+            flux coming from target + contaminants + sky. A number between 0 and 1.
 
         Notes
         -----
@@ -1862,7 +1870,7 @@ class SimFile (object):
         if starIDgroupName not in self.hdf5file["Photometry"]["Masks"].keys():
             print(f"Error: getPhotometricMask(): {starIDgroupName}" +
                   " not present in Photometry/Masks/ in the HDF5 file")
-            return None, None, None, None, None
+            return None, None, None, None, None, None
 
         # Fetch mask info and mask updates
         
@@ -1871,15 +1879,14 @@ class SimFile (object):
         numMaskUpdates = len(exposureNrOfMaskUpdate)
 
         # If a specific image number for the mask update is requested:
-        # NOTE masks are not updated for every exposure hence find most recent mask
+        # NOTE: masks are not updated for every exposure hence find most recent mask
 
-        if isinstance(imageNr, int):
+        if isinstance(imageNr, int):                                # imageNr is not None
 
             idx = np.searchsorted(exposureNrOfMaskUpdate, imageNr, side='right') - 1
             if idx < 0:
-                print("Error: getPhotometricMask(): " +
-                      "requesting an imageNr that is too early for this HDF5 file")
-                return None, None, None, None, None
+                print("Error: getPhotometricMask(): requesting an imageNr that is too early for this HDF5 file")
+                return None, None, None, None, None, None
 
             exposureNrOfMaskUpdate = exposureNrOfMaskUpdate[idx]
 
@@ -1887,6 +1894,7 @@ class SimFile (object):
 
             maskSize = np.array(mask[starIDgroupName]['maskSize'])[idx]
             maskNSR  = np.array(mask[starIDgroupName]['maskNSR'])[idx]
+            maskSPR = np.array(mask[starIDgroupName]['maskSPR'])[idx]
 
             # Extract the indices of the proper mask
 
@@ -1902,6 +1910,7 @@ class SimFile (object):
 
             maskSize = np.array(mask[starIDgroupName]['maskSize'])
             maskNSR  = np.array(mask[starIDgroupName]['maskNSR'])
+            maskSPR = np.array(mask[starIDgroupName]['maskSPR'])
 
             # Extract the indices of all masks
 
@@ -1916,7 +1925,7 @@ class SimFile (object):
 
         # Finito!
 
-        return rowIndices, colIndices, exposureNrOfMaskUpdate, maskSize, maskNSR
+        return rowIndices, colIndices, exposureNrOfMaskUpdate, maskSize, maskNSR, maskSPR
 
 
 

--- a/source/Detector.cpp
+++ b/source/Detector.cpp
@@ -605,7 +605,7 @@ void Detector::updateParameters(double time)
         readCTIinputFile(ctiInputFile);
         radiationSmearingMap.resize(numRowsSmearingMap, numColumnsPixelMap);
         radiationSmearingMap.fill(1.0);
-	numberOfOccupiedTrapsPixelMap = arma::zeros<arma::Mat<float>>(numTrapSpecies, numColumnsPixelMap);
+	    numberOfOccupiedTrapsPixelMap = arma::zeros<arma::Mat<float>>(numTrapSpecies, numColumnsPixelMap);
         numberOfOccupiedTrapsSmearingMap = arma::zeros<arma::Mat<float>>(numTrapSpecies, numColumnsPixelMap);
     }
     else
@@ -717,7 +717,7 @@ void Detector::readCTIinputFile(string ctiInputFile)
     arma::Mat<float> map(numRows, numColumns);
     CTIFile.readArray("/", "radiationMap", map);
 
-    // Rescale the radiatio  map so that it has mean = 1, and only keep the part relevant to subfield we're interested in.
+    // Rescale the radiation map so that it has mean = 1, and only keep the part relevant to subfield we're interested in.
 
     radiationMap.resize(numRowsPixelMap, numColumnsPixelMap);
     radiationMap = map.submat(subFieldZeroPointRow, subFieldZeroPointColumn, subFieldZeroPointRow+numRowsPixelMap-1, subFieldZeroPointColumn+numColumnsPixelMap-1);

--- a/source/DetectorWithAnalyticNonGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticNonGaussianPSF.cpp
@@ -201,6 +201,7 @@ void DetectorWithAnalyticNonGaussianPSF::configure(ConfigurationParameters &conf
             maskSizeTarget[starID] = vector<unsigned int>();
             NSRtarget[starID] = vector<double>();
             exposureNrOfMaskUpdate[starID] = vector<unsigned int>();
+            aggregatedSPR[starID] = vector<double>();
         }
     }
 
@@ -988,6 +989,9 @@ void DetectorWithAnalyticNonGaussianPSF::flushOutput()
             arrayName = "maskNSR";
             hdf5File.writeArray(groupName, arrayName, NSRtarget[starID].data(), NSRtarget[starID].size());
 
+            arrayName = "maskSPR";
+            hdf5File.writeArray(groupName, arrayName, aggregatedSPR[starID].data(), aggregatedSPR[starID].size());
+
             for(auto iter = rowIndexOfMaskOfTarget[starID].begin(); iter != rowIndexOfMaskOfTarget[starID].end(); ++iter)
             {
                 const unsigned int exposureNumber = iter->first;
@@ -1019,6 +1023,10 @@ void DetectorWithAnalyticNonGaussianPSF::flushOutput()
 
 /**
  * \brief Extract the photometric light curve for a specified list of stars
+ * 
+ * Based on the following article:
+ *    In-flight photometry extraction of PLATO targets. Optimal apertures for detecting extrasolar planets
+ *    Marchiori V. et al., 2019, A&A 627, 71
  *
  * TODO: - better error catching when the stars for which a lightcurve is requested are (sometimes) not in the subfield
  *       - better treatment when there are no contaminants
@@ -1098,7 +1106,7 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
     const int Ntargets = photStarIDs.size();                                     // Nr of stars for which we want a lightcurve
     if (Ntargets == 0)
     {
-        Log.warning("Detector:applyPhotometry: no stars found for which photometry is requested. Skipping applyPhotometry().");
+        Log.warning("Detector::applyPhotometry: no stars found for which photometry is requested. Skipping applyPhotometry().");
         return;
     }
 
@@ -1107,6 +1115,9 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
         // Collect info on the position and the input flux of the target
 
         int starID = photStarIDs[n];
+
+        Log.info("Detector::applyPhotometry: Computing photometry for star ID = " + to_string(starID)
+                 + " for exposure # " + to_string(exposureNr));
 
         double time;                                                      // Time stamp of the last exposure         [s]
         double xFPtarget;                                                 // Mean x-coordinate in the focal plane    [mm]
@@ -1119,7 +1130,8 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
 
         if (fluxTarget == -1.0)
         {
-            Log.warning("Detector:applyPhotometry: no info found for star " + to_string(starID) + " for which photometry is requested");
+            Log.warning("Detector:applyPhotometry: star ID " + to_string(starID) + " could not be found on the subfield "
+                        + "for exposure #" + to_string(exposureNr));
             continue;
         }
 
@@ -1204,6 +1216,7 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
             }
 
             // For the pixels in the designated area around our target, compute the variance and the noise/signal ratio of the signal.
+            // NSR = Noise-to-signal ratio
             // Example size: if the pixelMap is 100x100 pixels, and we consider a mask of 4x4 pixels, then NSRmap is a 2D array of size
             //               100x100, but flatNSRmap is a 1D array of size 16.
 
@@ -1252,6 +1265,10 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
             double aggregatedSingleTargetFlux    = singleTargetMap(rowIndex[0], colIndex[0]) * throughputMap(rowIndex[0], colIndex[0]);
             double aggregatedObservedTargetFlux  = image(rowIndex[0], colIndex[0]);
             double aggregatedNSR                 = NSRmap(rowIndex[0], colIndex[0]);
+            double aggregatedContaminantFlux = contaminantMap(rowIndex[0], colIndex[0]) * throughputMap(rowIndex[0], colIndex[0]);
+            double aggregatedTotalFlux   = (singleTargetMap(rowIndex[0], colIndex[0]) + contaminantMap(rowIndex[0], colIndex[0]) 
+                                                     + skyBackground) * throughputMap(rowIndex[0], colIndex[0]);
+
             maskSizeTarget[starID].push_back(1);
 
             rowIndexOfMaskOfTarget[starID][exposureNr] = {rowIndex[0]};
@@ -1272,22 +1289,27 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
                     aggregatedSingleTargetFlux   += singleTargetMap(rowIndex[i], colIndex[i]) * throughputMap(rowIndex[i], colIndex[i]);
                     aggregatedObservedTargetFlux += image(rowIndex[i], colIndex[i]);
                     aggregatedNSR = temp;
+                    aggregatedContaminantFlux += contaminantMap(rowIndex[i], colIndex[i]) * throughputMap(rowIndex[i], colIndex[i]);
+                    aggregatedTotalFlux += (singleTargetMap(rowIndex[i], colIndex[i]) + contaminantMap(rowIndex[i], colIndex[i]) 
+                                                             + skyBackground) * throughputMap(rowIndex[i], colIndex[i]);
                     maskSizeTarget.at(starID).back() += 1;
                     rowIndexOfMaskOfTarget.at(starID).at(exposureNr).push_back(rowIndex[i]);
                     colIndexOfMaskOfTarget.at(starID).at(exposureNr).push_back(colIndex[i]);
                 }
                 else
                 {
-                    // The aggregated Noise/Signal ratio did not improve by adding this pixel. Not only can we ignore exclude this pixel from the
-                    // mask, but also all subsequent ones that have an even worse noise/signal ratio. So finalize the mask for this target, and
-                    // then break out of the for-loop.
+                    // The aggregated Noise/Signal ratio did not improve by adding this pixel. Not only can we ignore exclude this pixel 
+                    // from the mask, but also all subsequent ones that have an even worse noise/signal ratio. So finalize the mask for 
+                    // this target, and then break out of the for-loop.
 
                     estimatedFluxTarget.at(starID).at(zeroBasedExposureNr) = aggregatedObservedTargetFlux;
                     varFluxTarget.at(starID).at(zeroBasedExposureNr) = aggregatedVariance;
                     NSRtarget.at(starID).push_back(aggregatedNSR);
+                    aggregatedSPR.at(starID).push_back(aggregatedContaminantFlux / aggregatedTotalFlux);
 
                     Log.debug("Detector::applyPhotometry: star ID " + to_string(starID) + " has a mask of " + to_string(i) + " pixels"
-                              " with aggregated S/N = " + to_string(1/aggregatedNSR));
+                              + " with aggregated S/N = " + to_string(1/aggregatedNSR)
+                              + " and SPR = " + to_string(aggregatedContaminantFlux / aggregatedTotalFlux));
 
                     // Disregard all other pixels of the window around the target star: they all contribute more to the noise than to the signal.
 
@@ -1302,7 +1324,8 @@ void DetectorWithAnalyticNonGaussianPSF::applyPhotometry(const unsigned int expo
         }
         else
         {
-            // For all other exposures, simply use the same (most recent) mask. We reuse the NSR of the previous mask, so no need to recompute it.
+            // For all other exposures, simply use the same (most recent) mask. 
+            // We reuse the NSR of the previous mask, so no need to recompute it. Idem for the SPR.
 
             Log.debug("Detector::applyPhotometry: extracting flux for target ID " + to_string(starID) + " for exposure " + to_string(exposureNr) + " with an old mask");
 

--- a/tests/validationTests/scripts/run.py
+++ b/tests/validationTests/scripts/run.py
@@ -42,6 +42,7 @@ from metallicShield                                import MetallicShield
 from quaternion                                    import Quaternion                   
 from RefFrames.focalPlaneCoordinates               import FocalPlaneCoordinates
 from nonlineargain                                 import NonlinearGainTest 
+from spr                                           import SPRTest
 
 
 from contextlib import contextmanager
@@ -120,8 +121,10 @@ myTests = [
     (DarkSignalNonUniformity(),    "Dark Signal Non Uniformity"),
     (TempVariationOfCCD(),         "Temperature Variation of CCD"),
     (FocalPlaneCoordinates(),      "Orientation CAM ref frame in (RA, dec) plane"),
-    (NonlinearGainTest(),          "Nonlinear gain")
+    (NonlinearGainTest(),          "Nonlinear gain"),
+    (SPRTest(),                    "Stellar pollution ratio (SPR)")
 ]                                  
+
 
 
 def runTheTest(description, test, i):

--- a/tests/validationTests/scripts/spr.py
+++ b/tests/validationTests/scripts/spr.py
@@ -1,0 +1,252 @@
+
+import os
+import numpy as np
+from test import Test,eprint
+from platosim.simulation import Simulation
+
+
+
+# Class to test the Stellar pollution ratio
+
+class SPRTest(Test):
+
+    def __init__(self) -> None:
+
+        # Create the folder where all simulation output files will be written
+
+        self.nr = 9325
+        self.outputDir = os.environ["PLATO_PROJECT_HOME"] + f"/tests/validationTests/ioFiles/test{self.nr}"
+        if not os.path.isdir(self.outputDir):
+            os.mkdir(self.outputDir)
+
+        # Select the input configuration yaml file
+
+        self.inputDir = os.environ["PLATO_PROJECT_HOME"] + "/inputfiles/"
+        self.inputfile = os.environ["PLATO_PROJECT_HOME"] + "/inputfiles/inputfile.yaml"
+
+
+
+
+    def runSPRTestWithOneStar(self) -> bool:
+        """ 
+        Test: if there is only one star in the subfield, the SPR should be 0.0.
+        """
+
+        starIDs = np.array([1])
+            
+        # We'll use the CCD#1 of a normal camera. The exact position of the imagette on the CCD is not important. 
+        # It's size is taken small as we only have one or two stars in our catalog.
+
+        ccdCode = '1'
+        xCCDpixel = 100                   # Column coordinate
+        yCCDpixel = 100                   # Row coordinate
+        subfieldSizeX = 10
+        subfieldSizeY = 10
+
+        # Run the simulator
+
+        sim = Simulation(f"test{self.nr}_SPR_one_star", configurationFile = self.inputfile, outputDir = self.outputDir)
+
+        # Be sure to switch on photometry, and save the star ID in the photomtry file, so that the light curve is extracted
+
+        sim["Photometry/IncludePhotometry"] = "yes"
+        sim["Photometry/TargetFileName"] = self.outputDir + "myphotometry.txt"
+        np.savetxt(self.outputDir + "myphotometry.txt", starIDs, fmt="%d")
+
+        # Create a small imagette around the star
+
+        success = sim.setSubfieldAroundPixelCoordinates(ccdCode, xCCDpixel, yCCDpixel, subfieldSizeX, subfieldSizeY)
+        if not success: 
+            eprint("Error: could not set subfield around star")
+            return
+
+        # Create a star catalog with the proper star ID, and a magnitude of 10.5
+
+        starCatalogName = self.outputDir + "/starCatalog.txt"
+        sim.createStarCatalogFileFromPixelCoordinates(np.array([yCCDpixel]), np.array([xCCDpixel]), np.array([10.5]),   \
+                                                      starIDs, starCatalogName)
+        sim["ObservingParameters/StarCatalogFile"] = starCatalogName
+
+        # We only need one exposure to determine the SPR
+        
+        sim["ObservingParameters/NumExposures"] = 1
+
+        # Run the PlatoSim simulator 
+
+        simFile = sim.run(removeOutputFile=True)
+        dummy, dummy, dummy, dummy, dummy, SPR = simFile.getApertureMask(starIDs[0])
+
+        if SPR[0] == 0.0:
+            return True
+        else:
+            return False
+
+
+
+
+
+
+
+    def runSPRTestWithTwoEqualApproachingStars(self) -> bool:
+        """ 
+        Test with two stars: the nearer the stars, the larger the SPR should become
+        """
+
+        # The entire catalog only consists of 2 stars:
+
+        starIDs = np.array([1,2])
+            
+        # For only 1 star we need the photometry. That one is the target, the other one is the contaminant
+
+        np.savetxt(self.outputDir + "myphotometry.txt", np.array([1]), fmt="%d")
+
+        # We'll use the CCD#1 of a normal camera. The exact position of the imagette on the CCD is not important. 
+        # It's size is taken small as we only have one or two stars in our catalog.
+
+        ccdCode = '1'
+        xCCDpixel_center = 100                   # Column coordinate
+        yCCDpixel_center = 100                   # Row coordinate
+        subfieldSizeX = 10
+        subfieldSizeY = 10
+
+        # Run the simulator for three different distances between the two stars
+
+        SPRs = []
+        for n in range(3):
+
+            sim = Simulation(f"test{self.nr}_SPR_two_stars_dist{n}", configurationFile = self.inputfile, outputDir = self.outputDir)
+
+            # Be sure to switch on photometry, and save the star ID in the photomtry file, so that the light curve is extracted
+
+            sim["Photometry/IncludePhotometry"] = "yes"
+            sim["Photometry/TargetFileName"] = self.outputDir + "myphotometry.txt"
+
+            # Create a small imagette around the star
+
+            success = sim.setSubfieldAroundPixelCoordinates(ccdCode, xCCDpixel_center, yCCDpixel_center, subfieldSizeX, subfieldSizeY)
+            if not success: 
+                eprint("Error: could not set subfield around star")
+                return
+
+            # Create a star catalog with the proper star ID, and the magnitudes both 10.5
+            # Same y-coordinate, but increasing x-coordinate.
+
+            starCatalogName = self.outputDir + "/starCatalog.txt"
+            Vmags = np.array([10.5, 10.5])
+            xpixCoord = np.array([xCCDpixel_center, xCCDpixel_center+n+1])
+            ypixCoord = np.array([yCCDpixel_center, yCCDpixel_center])
+            sim.createStarCatalogFileFromPixelCoordinates(ypixCoord, xpixCoord, Vmags,   \
+                                                          starIDs, starCatalogName)
+            sim["ObservingParameters/StarCatalogFile"] = starCatalogName
+
+            # We only need one exposure to determine the SPR
+            
+            sim["ObservingParameters/NumExposures"] = 1
+
+            # Run the PlatoSim simulator 
+
+            simFile = sim.run(removeOutputFile=True)
+            dummy, dummy, dummy, dummy, dummy, SPR = simFile.getApertureMask(starIDs[0])
+
+            SPRs.append(SPR[0])
+
+        # Verify if they are all between 0 and 1 and that the SPR is decreasing with 
+        # increasing distance.
+        
+        if 1 > SPRs[0] > SPRs[1] > SPRs[2] > 0:
+            return True
+        else:
+            return False
+
+
+
+
+
+
+
+    def runSPRTestWithTwoUnequalStars(self) -> bool:
+        """ 
+        Test with two stars: the brighter the contaminant, the larger the SPR should become.
+        """
+
+        # The entire catalog only consists of 2 stars:
+
+        starIDs = np.array([1,2])
+            
+        # For only 1 star we need the photometry. That one is the target, the other one is the contaminant
+
+        np.savetxt(self.outputDir + "myphotometry.txt", np.array([1]), fmt="%d")
+
+        # We'll use the CCD#1 of a normal camera. The exact position of the imagette on the CCD is not important. 
+        # It's size is taken small as we only have one or two stars in our catalog.
+
+        ccdCode = '1'
+        xCCDpixel_center = 100                   # Column coordinate
+        yCCDpixel_center = 100                   # Row coordinate
+        subfieldSizeX = 10
+        subfieldSizeY = 10
+
+        # Run the simulator for three different magnitudes of the contaminant
+
+        starCatalogName = self.outputDir + "/starCatalog.txt"
+        xpixCoord = np.array([xCCDpixel_center, xCCDpixel_center+2])
+        ypixCoord = np.array([yCCDpixel_center, yCCDpixel_center])
+
+        SPRs = []
+        for n in range(3):
+
+            sim = Simulation(f"test{self.nr}_SPR_two_stars_mag{n}", configurationFile = self.inputfile, outputDir = self.outputDir)
+
+            # Be sure to switch on photometry, and save the star ID in the photomtry file, so that the light curve is extracted
+
+            sim["Photometry/IncludePhotometry"] = "yes"
+            sim["Photometry/TargetFileName"] = self.outputDir + "myphotometry.txt"
+
+            # Create a small imagette around the star
+
+            success = sim.setSubfieldAroundPixelCoordinates(ccdCode, xCCDpixel_center, yCCDpixel_center, subfieldSizeX, subfieldSizeY)
+            if not success: 
+                eprint("Error: could not set subfield around star")
+                return
+
+            # Create a star catalog with the proper star IDs, the magnitudes of the target = 10.5,
+            # and the magnitude of the contaminant 10.5, 11.5, and 12.5
+
+            Vmags = np.array([10.5, 10.5+n])
+            sim.createStarCatalogFileFromPixelCoordinates(ypixCoord, xpixCoord, Vmags, starIDs, starCatalogName)
+            sim["ObservingParameters/StarCatalogFile"] = starCatalogName
+
+            # We only need one exposure to determine the SPR
+            
+            sim["ObservingParameters/NumExposures"] = 1
+
+            # Run the PlatoSim simulator 
+
+            simFile = sim.run(removeOutputFile=True)
+            dummy, dummy, dummy, dummy, dummy, SPR = simFile.getApertureMask(starIDs[0])
+
+            SPRs.append(SPR[0])
+
+        # Verify if they are all between 0 and 1 and that the SPR is decreasing with increasing magnitude of the contaminant
+        
+        if 1 > SPRs[0] > SPRs[1] > SPRs[2] > 0:
+            return True
+        else:
+            return False
+
+
+
+    def run(self) -> bool:
+        success1 = self.runSPRTestWithOneStar()
+        success2 = self.runSPRTestWithTwoEqualApproachingStars()
+        success3 = self.runSPRTestWithTwoUnequalStars()
+        return success1 and success2 and success3
+
+
+
+if __name__ == "__main__":
+    myTest = SPRTest()
+    print(myTest.runSPRTestWithOneStar())
+    print(myTest.runSPRTestWithTwoEqualApproachingStars())
+    print(myTest.runSPRTestWithTwoUnequalStars())
+


### PR DESCRIPTION
## Summary

The stellar pollution ratio (SPR, cf Marchiori et al. (2019) their Eqs. 14-17) is computed and saved to the HDF5 file in the location `Photometry/Masks/starID####/maskSPR`.

## Details

- The SPR is computed in the function `applyPhotometry()` in `DetectorWithAnalyticNonGaussianPSF.cpp`. 
- In `simfile.py` the function `getApertureMask()` was modified so that it now also returns the SPR.
- Three validation tests were added to the validation suite.

## Breaking changes

- The function `getApertureMask()` in `simfile.py` now returns 6 items instead of 5.