### PR TITLE
Update of lightcurve.py and picsim

### DIFF
--- a/python/platosim/lightcurve.py
+++ b/python/platosim/lightcurve.py
@@ -1049,10 +1049,9 @@ class LightCurve(object):
 
     
     def detrend(self, column='flux', model="poly",
-                degree=False, gradient=False,            # Model -> Polynomial
-                method="biweight", window=3, mask=None,  # Model -> Wotan
-                gapsize=0.1, segments=True,
-                replace=False, plot=False):
+                degree=False, gradient=False,                      # Model -> Polynomial
+                method="biweight", window=3, tbin=1/6, mask=None,  # Model -> Wotan
+                segments=True, replace=False, plot=False):
                 
         """Detrend time series.
 
@@ -1060,7 +1059,7 @@ class LightCurve(object):
         a simply polynomial model or the Wotan module specialized for
         exoplanet transit vetting.
 
-        NOTE: Wotan removed stellar variability (spots modulation, pulsations,
+        NOTE: Wotan removes stellar variability (spots modulation, pulsations,
               and granulation) so another module is needed to preserve these.
 
         Parameters
@@ -1076,8 +1075,16 @@ class LightCurve(object):
             Method to be used by Wotan (wotan parameter)
         window : float
             Window size to be used for detrending [days] (wotan parameter)
+        tbin : float
+            Time duration to bin data before running Wotan (for speed)
         mask : bool, float
             List with [period, duration, t0] to mask out periodic signal [all in days]
+        segments : bool
+            Flag to perform detrending on mask-update segments
+        replace : bool
+            Flag to replace 'flux' column in df with 'flux_detrend' column
+        plot : bool
+            Flag to activate dianostic plot of module
         """
         
         # Remove clipped NaNs
@@ -1098,7 +1105,7 @@ class LightCurve(object):
         # Prepare arrays to store light curve
         flux_detrend = np.zeros_like(time)
         flux_trend   = np.zeros_like(time)
-        poly_deg = []
+
         # POLYNOMIAL MODEL
 
         if model == "poly":
@@ -1109,7 +1116,7 @@ class LightCurve(object):
                 time_segment = time[dex[i]:dex[i+1]]
                 flux_segment = flux[dex[i]:dex[i+1]]
 
-                # Select
+                # Use model selection if None
                 if degree:
                     deg = degree
                 else:
@@ -1122,23 +1129,22 @@ class LightCurve(object):
                     fit1 = sm.OLS.from_formula(formula=model1, data=df).fit()
                     fit2 = sm.OLS.from_formula(formula=model2, data=df).fit()
                     fit3 = sm.OLS.from_formula(formula=model3, data=df).fit()
-                    AIC_j = [fit1.aic, fit2.aic, fit3.aic]
-                    BIC_j = [fit1.bic, fit2.bic, fit3.bic]
-                    deg = st.model_selection(AIC_j, BIC_j, show=False)
-                    poly_deg.append(deg)
-                    
-                    # Check if a higher degree is needed
-                    # dt = len(time_segment)*25/86400
-                    # if dt > 60:
-                    #     if ( (deg == 1 and fit2.bic > fit1.bic) or
-                    #          (deg == 2 and fit3.bic > fit2.bic) ):
-                    #         deg += 1
-                    #------------------ Debugging
+                    #---------------------------- Debugging
                     # print(deg, fit1.rsquared, fit2.rsquared, fit3.rsquared, dt) 
                     # print(fit1.summary())
                     # print(fit2.summary())
                     # print(fit3.summary())
-                    #----------------------------
+                    #-------------------------------------
+                    AIC_j = [fit1.aic, fit2.aic, fit3.aic]
+                    BIC_j = [fit1.bic, fit2.bic, fit3.bic]
+                    deg = st.model_selection(AIC_j, BIC_j, show=False)
+                    
+                    # Check if a higher degree is needed
+                    dt = len(time_segment)*25/86400
+                    if dt > 60:
+                        if ( (deg == 1 and fit2.bic > fit1.bic) or
+                             (deg == 2 and fit3.bic > fit2.bic) ):
+                            deg += 1
                     
                 # Perform fit
                 poly = np.polyfit(time_segment, flux_segment, deg=deg)
@@ -1168,43 +1174,32 @@ class LightCurve(object):
             # Run Wotan in segments after mask-updates
             for i in range(len(dex)-1):
 
-                # Bin data per 1h for robust detrending
+                # Mask-update segments
                 time_i = time[dex[i]:dex[i+1]]
                 flux_i = flux[dex[i]:dex[i+1]]
-                dx = pd.DataFrame({'time': time_i, 'flux':flux_i})
-                lc = LightCurve(dx, 'multi')
-                df = lc.bin(binsize=0.5)
-                df.time *= 3600. # [d -> s]
-                
-                # Perform detrending
-                _, trend = wotan.flatten(df.time,
-                                         df.flux,
+
+                # Bin data per 10min for robust detrending
+                tday_i = time_i / 86400.
+                tdur = tday_i.iloc[-1] - tday_i.iloc[0]
+                bins = int(tdur/tbin)
+                flux_bin, time_bin, _ = binned_statistic(tday_i, flux_i, 'median', bins=bins)
+                time_bin = time_bin[:-1] + np.diff(time_bin)[0]/2.
+
+                # Perform detrending [Wotan needs time units in days!]
+                _, trend = wotan.flatten(time_bin,
+                                         flux_bin,
                                          method=method,
-                                         window_length=window*c.day,
-                                         break_tolerance=gapsize*c.day,
+                                         window_length=window,
                                          edge_cutoff=0.0,
                                          return_trend=True,
                                          robust=True,
                                          mask=mask)
-                
+
                 # Interpolate back to original cadence
-                spline_trend = make_interp_spline(df.time, trend, k=1)
+                spline_trend = make_interp_spline(time_bin*86400, trend, k=1)
                 flux_detrend[dex[i]:dex[i+1]] = flux_i / spline_trend(time_i)
                 flux_trend[dex[i]:dex[i+1]]   = spline_trend(time_i)
-                
-            # Run Wotan in segments after mask-updates
-            # for i in range(len(dex)-1):
-            #     data = wotan.flatten(time[dex[i]:dex[i+1]],
-            #                          flux[dex[i]:dex[i+1]],
-            #                          method=method,
-            #                          window_length=window*c.day,
-            #                          break_tolerance=gapsize*c.day,
-            #                          return_trend=True,
-            #                          robust=True,
-            #                          mask=mask)
-            #     flux_detrend[dex[i]:dex[i+1]] = data[0]
-            #     flux_trend[dex[i]:dex[i+1]]   = data[1]
-                
+                                
         # PROLOGUE
                 
         # Convert into ppm
@@ -1225,7 +1220,6 @@ class LightCurve(object):
 
 
     
-
     
     def plot_detrend(self, df, column='flux', figsize=(9,8)):
 
@@ -2113,7 +2107,7 @@ class LightCurve(object):
             
         # Plot quarter marks
         ymax = np.max(flux_max)
-        ypos = ymax + ymax * ax.margins()[1]/13
+        ypos = ymax + ymax * ax.margins()[1]/7
         for q in np.unique(Q):
             time_Q = q*ut.quarter()
             xpos = time_Q - 50

--- a/python/platosim/lightcurve.py
+++ b/python/platosim/lightcurve.py
@@ -1098,7 +1098,7 @@ class LightCurve(object):
         # Prepare arrays to store light curve
         flux_detrend = np.zeros_like(time)
         flux_trend   = np.zeros_like(time)
-        
+        poly_deg = []
         # POLYNOMIAL MODEL
 
         if model == "poly":
@@ -1125,19 +1125,20 @@ class LightCurve(object):
                     AIC_j = [fit1.aic, fit2.aic, fit3.aic]
                     BIC_j = [fit1.bic, fit2.bic, fit3.bic]
                     deg = st.model_selection(AIC_j, BIC_j, show=False)
-
+                    poly_deg.append(deg)
+                    
                     # Check if a higher degree is needed
-                    dt = len(time_segment)*25/86400
-                    if dt > 60:
-                        if ( (deg == 1 and fit2.bic > fit1.bic) or
-                             (deg == 2 and fit3.bic > fit2.bic) ):
-                            deg += 1
-                    #---------- Debugging
+                    # dt = len(time_segment)*25/86400
+                    # if dt > 60:
+                    #     if ( (deg == 1 and fit2.bic > fit1.bic) or
+                    #          (deg == 2 and fit3.bic > fit2.bic) ):
+                    #         deg += 1
+                    #------------------ Debugging
                     # print(deg, fit1.rsquared, fit2.rsquared, fit3.rsquared, dt) 
                     # print(fit1.summary())
                     # print(fit2.summary())
                     # print(fit3.summary())
-                    #---------- Debugging
+                    #----------------------------
                     
                 # Perform fit
                 poly = np.polyfit(time_segment, flux_segment, deg=deg)

--- a/python/platosim/platonium/picsim.py
+++ b/python/platosim/platonium/picsim.py
@@ -877,13 +877,15 @@ Notes on PIC catalogue creation:
         """
 
         if self.verbose > 1:
-            errorcode('software', '\nVizier PLATO FOV query')
+            errorcode('software', '\nVizier PLATO FOV query\n')
 
         # Arguments for GaiaDR3 star query        
-        self.field  = args.vizier
-        self.bright = args.yale_stars
-        self.astro  = args.gaia_astro
-
+        self.field    = args.vizier
+        self.bright   = args.yale_stars
+        self.stellar  = args.gaia_stellar
+        self.variable = args.gaia_variable
+        self.quasar   = args.gaia_quasar
+        
         # Magnitude limits
         if args.magmin is None:
             self.magmin = 0
@@ -902,7 +904,7 @@ Notes on PIC catalogue creation:
             errorcode('error', 'Option --vizier needs a output destination!')
 
         # Check for inconsitent query
-        if self.bright and self.astro:
+        if self.bright and self.stellar:
             errorcode('error', 'Flags "yale_stars" and "gaia_astro" cannot be parsed at once!')
             
         # Constants [deg]
@@ -1040,17 +1042,21 @@ Notes on PIC catalogue creation:
         Authors: Juan Cabrera & Nicholas Jannsen
         https://www.cosmos.esa.int/web/gaia-users/archive/programmatic-access
         """
-                
+
         if self.verbose > 1:
-            print('\nStart Gaia DR3 query using magnitude limits: ' +
-                  f'{self.magmin} - {self.magmax}')
-            
+            print(f'Adding stellar  columns : {self.stellar}')
+            print(f'Adding variable columns : {self.variable}')
+            print(f'Adding quasar   columns : {self.quasar}')
+            print(f'\nStart Gaia DR3 query for magnitudes : {self.magmin} - {self.magmax}')
+
         # Query stars within the FOV of each grid
         for i in tqdm(range(len(self.raGrid)), bar_format=ut.tqdmBar()):
             
             df0 = sq.gaiaRegionQuery(self.raGrid[i], self.decGrid[i], radius=self.r,
                                      maglim_min=self.magmin, maglim_max=self.magmax,
-                                     flag_astro=self.astro, flag_quasar=True,
+                                     flag_stellar=self.stellar,
+                                     flag_variable=self.variable,
+                                     flag_quasar=self.quasar,
                                      ofile=f'{self.filename}.vot')
 
             # Contatenate catalogue
@@ -1106,10 +1112,95 @@ Notes on PIC catalogue creation:
             df0.reset_index(drop=True, inplace=True)
             df0.to_feather(ofile)
 
-            
+        # Run PLATOnium simulations to create final catalogue
+        self.flag_combine = True
+        if self.flag_combine:
 
-        
-        
+            if self.verbose > 1:
+                print(f'\nRunning PLATOnium find stars within the focal plane')
+                
+            # Copy YAML to output
+            ut.copyVizierInputYAML(self.field, self.outputDir)
+            platonium=os.getenv('PLATO_PROJECT_HOME')+'/python/platosim/platonium/platonium.py'
+
+            # Query stars within the FOV of each grid
+            for ccd in tqdm(range(1,5), bar_format=ut.tqdmBar()):
+                for group in range(1,5):
+                    os.system(f'python {platonium} {ccd} {group} 1 1 --fullframe ' +
+                              f'-i {self.outputDir}/inputfile_vizier.yaml ' +
+                              f'-o {self.outputDir} --nexp 1 -v 0 -w')
+
+            if self.verbose > 1:
+                print(f'\nCombing catalogues into final PLATO {self.field} catalogue')
+
+            # Load full-frame stellar catalogues
+            group, cam = 1, 1
+            df11 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd1.ftr")
+            df12 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd2.ftr")
+            df13 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd3.ftr")
+            df14 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd4.ftr")
+            group, cam = 2, 1
+            df21 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd1.ftr")
+            df22 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd2.ftr")
+            df23 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd3.ftr")
+            df24 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd4.ftr")
+            group, cam = 3, 1
+            df31 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd1.ftr")
+            df32 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd2.ftr")
+            df33 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd3.ftr")
+            df34 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd4.ftr")
+            group, cam = 4, 1
+            df41 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd1.ftr")
+            df42 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd2.ftr")
+            df43 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd3.ftr")
+            df44 = pd.read_feather(f"{self.outputDir}/Ncam{group}.{cam}_Q1_ccd4.ftr")
+
+            # Remove all files again after loaded
+            os.system(f'rm {self.outputDir}/Ncam*')
+            os.system(f'rm {self.outputDir}/inputfile_vizier.yaml')
+            
+            # Combine all CCD catalogue into one
+            df = pd.concat([df11, df12, df13, df14, df21, df22, df23, df24,
+                            df31, df32, df33, df34, df41, df42, df43, df44])
+
+            # Drop a few columns
+            df = df.drop(columns=['xCCD', 'yCCD', 'xFP', 'yFP', 'rOA'])
+
+            # Sort after gaia DR3
+            df = df.sort_values(by=['gaiaDR3'])
+
+            # Fetch N-CAM group visibility
+            N = df.shape[0]
+            ncams = np.zeros(N)
+            if self.verbose > 1:
+                print('\nFetching the N-CAM observability for each star:')
+
+            for i in tqdm(range(N), bar_format=ut.tqdmBar()):
+
+                # Fetch 4 values ahead (since max 4 groups)
+                dx = df.iloc[i:i+4]
+
+                # Subtract star ID and count zeros = N-CAM visibility:
+                # Row with highest ncams value is the one we keep below
+                diff = np.array(dx.gaiaDR3).astype(int) - int(dx.gaiaDR3.iloc[0])
+                ncams[i] = np.count_nonzero(diff==0)
+
+            # Add column 
+            df['ncams'] = (ncams * 6).astype(int)
+
+            # Drop dublicates and keep highest count
+            df = df.drop_duplicates(subset=['gaiaDR3'])
+
+            # Sort after ncams and Pmag
+            df0 = df.sort_values(by=['ncams', 'Pmag'])
+
+            # Save catalogue be used by varsim
+            df0.reset_index(drop=True, inplace=True)
+            df0.to_feather(f'{self.outputDir}/starcat_GaiaDR3_{self.field}.ftr')
+
+
+
+            
 #==============================================================#
 #               PARSING COMMAND-LINE ARGUMENTS                 #
 #==============================================================#
@@ -1143,8 +1234,10 @@ viz_group = parser.add_argument_group('VIZIER QUERY (PLATO FOV)')
 viz_group.add_argument('--vizier', type=str,   metavar='FIELD', help='PLATO pointing field')
 viz_group.add_argument('--magmin', type=float, metavar='MAG',   help='Min magnitude to query (Default: 0 mag)')
 viz_group.add_argument('--magmax', type=float, metavar='MAG',   help='Max magnitude to query (Default: 15 mag)')
-viz_group.add_argument('--yale_stars', action='store_true',     help='Flag to add the Yale bright stars catalogue')
-viz_group.add_argument('--gaia_astro', action='store_true',     help='Flag to add parameters from the Astrophysical Gaia table')
+viz_group.add_argument('--yale_stars',    action='store_true',  help='Flag to add the Yale bright stars catalogue')
+viz_group.add_argument('--gaia_stellar',  action='store_true',  help='Flag to add stellar parameters to catalogue')
+viz_group.add_argument('--gaia_variable', action='store_true',  help='Flag to add variabe parameters to catalogue')
+viz_group.add_argument('--gaia_quasar',   action='store_true',  help='Flag to add Quasars parameters to catalogue')
 
 que_group = parser.add_argument_group('GENERIC QUERY OPTIONS')
 que_group.add_argument('--dmag', type=int, metavar='MAG',    help='Delta magnitude target-to-contaminant limit (Default: 5 mag)')

--- a/python/platosim/starquery.py
+++ b/python/platosim/starquery.py
@@ -365,7 +365,8 @@ def gaiaRegionQuerySmall(alpha, delta, radius=1, maglim=21):
 
 
 def gaiaRegionQuery(ra, dec, radius=1, maglim_min=0, maglim_max=17,
-                    flag_astro=False, flag_quasar=False, ofile=False):
+                    flag_stellar=False, flag_variable=False, flag_quasar=False,
+                    ofile=False):
 
     """Function to query a circular sky region from Gaia DR3.
     
@@ -392,83 +393,57 @@ def gaiaRegionQuery(ra, dec, radius=1, maglim_min=0, maglim_max=17,
     See: "Search" -> "Advanced (ADQL)" -> "Gaia Data Release 3"
 
     NOTE Query only valid for Gmag < 17, else gaps are intoduced!
-    Use additional queries e.g. in bins of 1 mag for Gmah > 17.
+    Use additional queries e.g. in bins of 0.5 mag for Gmag > 17.
     """
 
     # Fetch columns from catalogues
+    colname = ['gaia.designation',
+               'gaia.source_id',
+               'gaia.ra',
+               'gaia.dec',
+               'gaia.phot_g_mean_mag',
+               'gaia.bp_rp',
+               'gaia.ag_gspphot',
+               'gaia.parallax', 'gaia.parallax_error',
+               'gaia.pmra',
+               'gaia.pmdec',
+               'gaia.ruwe']
 
-    if flag_astro:
-        colname = ['gaia.source_id',
-                   'gaia.ra',
-                   'gaia.dec',
-                   'gaia.phot_g_mean_mag',
-                   'gaia.bp_rp',
-                   'gaia.ag_gspphot',
-                   'gaia.parallax', 'gaia.parallax_error',
-                   'gaia.pmra',
-                   'gaia.pmdec',
-                   'gaia.ruwe',
-                   'gaia.mh_gspphot',    'gaia.mh_gspphot_lower',    'gaia.mh_gspphot_upper',
-                   'gaia.logg_gspphot',  'gaia.logg_gspphot_lower',  'gaia.logg_gspphot_upper',
-                   'gaia.teff_gspphot',  'gaia.teff_gspphot_lower',  'gaia.teff_gspphot_upper',
-                   'astro.radius_flame', 'astro.radius_flame_lower','astro.radius_flame_upper',
-                   'astro.mass_flame',   'astro.mass_flame_lower',   'astro.mass_flame_upper',
-                   'astro.lum_flame',    'astro.lum_flame_lower',    'astro.lum_flame_upper',
-                   'astro.activityindex_espcs', 'astro.activityindex_espcs_uncertainty',
-                   'astro.spectraltype_esphs',  'astro.evolstage_flame',
-                   'gaia.phot_variable_flag',   'astro.classlabel_espels']
+    if flag_stellar:
+        c = ['gaia.mh_gspphot',    'gaia.mh_gspphot_lower',    'gaia.mh_gspphot_upper',
+             'gaia.logg_gspphot',  'gaia.logg_gspphot_lower',  'gaia.logg_gspphot_upper',
+             'gaia.teff_gspphot',  'gaia.teff_gspphot_lower',  'gaia.teff_gspphot_upper',
+             'astro.radius_flame', 'astro.radius_flame_lower', 'astro.radius_flame_upper',
+             'astro.mass_flame',   'astro.mass_flame_lower',   'astro.mass_flame_upper',
+             'astro.lum_flame',    'astro.lum_flame_lower',    'astro.lum_flame_upper',
+             'astro.spectraltype_esphs',
+             'astro.evolstage_flame']
+        for i in c: colname.append(i)
 
-        columns = ', '.join(colname)    
-        query_base = f"""SELECT
-        {columns}
-        FROM gaiadr3.gaia_source AS gaia
-        JOIN gaiadr3.astrophysical_parameters AS astro
-          ON gaia.source_id = astro.source_id
-        WHERE 1=CONTAINS(
-          POINT(gaia.ra, gaia.dec),
-          CIRCLE({ra}, {dec}, {radius}))
-          AND gaia.phot_g_mean_mag > {maglim_min}
-          AND gaia.phot_g_mean_mag < {maglim_max}        
-        """
+    if flag_variable:
+        c = ['gaia.phot_variable_flag',
+             'astro.classlabel_espels',
+             'astro.activityindex_espcs', 'astro.activityindex_espcs_uncertainty']
+        for i in c: colname.append(i)
         
-    elif flag_quasar:
-        colname = ['gaia.source_id',
-                   'gaia.ra',
-                   'gaia.dec',
-                   'gaia.phot_g_mean_mag',
-                   'gaia.bp_rp',
-                   'astro.classprob_dsc_combmod_quasar']
-        columns = ', '.join(colname)    
-        query_base = f"""SELECT
-        {columns}
-        FROM gaiadr3.gaia_source AS gaia
-        JOIN gaiadr3.astrophysical_parameters AS astro
-          ON gaia.source_id = astro.source_id
-        WHERE 1=CONTAINS(
-          POINT(gaia.ra, gaia.dec),
-          CIRCLE({ra}, {dec}, {radius}))
-          AND astro.classprob_dsc_combmod_quasar > 0.9          
-          AND gaia.phot_g_mean_mag > {maglim_min}
-          AND gaia.phot_g_mean_mag < {maglim_max}
-          
-        """        
-        
-    else:
-        colname = ['gaia.source_id',
-                   'gaia.ra',
-                   'gaia.dec',
-                   'gaia.phot_g_mean_mag',
-                   'gaia.bp_rp']
-        columns = ', '.join(colname)    
-        query_base = f"""SELECT
-        {columns}
-        FROM gaiadr3.gaia_source AS gaia
-        WHERE 1=CONTAINS(
-          POINT(gaia.ra, gaia.dec),
-          CIRCLE({ra}, {dec}, {radius}))
-          AND gaia.phot_g_mean_mag > {maglim_min}
-          AND gaia.phot_g_mean_mag < {maglim_max}        
-        """
+    if flag_quasar:
+        c = ['astro.classprob_dsc_combmod_quasar']
+        for i in c: colname.append(i)
+
+    # Construct query cone
+    
+    columns = ', '.join(colname)    
+    query_base = f"""SELECT
+    {columns}
+    FROM gaiadr3.gaia_source AS gaia
+    JOIN gaiadr3.astrophysical_parameters AS astro
+      ON gaia.source_id = astro.source_id
+    WHERE 1=CONTAINS(
+      POINT(gaia.ra, gaia.dec),
+      CIRCLE({ra}, {dec}, {radius}))
+      AND gaia.phot_g_mean_mag > {maglim_min}
+      AND gaia.phot_g_mean_mag < {maglim_max}        
+    """
         
     # We use the urllib to keep the connection open because
     # the sky regions are huge which fails with Gaia.lunch_job
@@ -544,17 +519,18 @@ def gaiaRegionQuery(ra, dec, radius=1, maglim_min=0, maglim_max=17,
     votable = parse(ofile)
     df = ut.votable2pandas(votable)
     os.remove(ofile)
-    
+
     # Rename columns
 
-    if flag_astro:
-        df = df.rename(columns={'source_id': 'gaiaDR3',
-                                'phot_g_mean_mag': 'Gmag',
-                                'bp_rp': 'BP_RP',
-                                'ag_gspphot': 'Ag',
-                                'parallax': 'plx',
-                                'parallax_error': 'plx_err',
-                                'mh_gspphot': 'Z',
+    df = df.rename(columns={'source_id': 'gaiaDR3',
+                            'phot_g_mean_mag': 'Gmag',
+                            'bp_rp': 'BP_RP',
+                            'ag_gspphot': 'Ag',
+                            'parallax': 'plx',
+                            'parallax_error': 'plx_err'})
+
+    if flag_stellar:
+        df = df.rename(columns={'mh_gspphot': 'Z',
                                 'mh_gspphot_lower': 'Z_low',
                                 'mh_gspphot_upper': 'Z_upp',
                                 'logg_gspphot': 'logg',
@@ -572,28 +548,36 @@ def gaiaRegionQuery(ra, dec, radius=1, maglim_min=0, maglim_max=17,
                                 'lum_flame': 'L',
                                 'lum_flame_lower': 'L_low',
                                 'lum_flame_upper': 'L_upp',
-                                'activityindex_espcs': 'S',
-                                'activityindex_espcs_uncertainty': 'S_err',
                                 'spectraltype_esphs': 'spec',
-                                'evolstage_flame': 'evol',
-                                'phot_variable_flag': 'variable',
-                                'classlabel_espels': 'class'})
-        df = df.sort_values(by=['BP_RP'])
+                                'evolstage_flame': 'evol'})
         # Round Teff column
         df = df.fillna(-1)
         df = df.astype({'Teff':int,
                         'Teff_low':int,
                         'Teff_upp':int})
         df = df.replace({-1:np.nan})
-    else:
-        df = df.rename(columns={'source_id': 'gaiaDR3',
-                                'phot_g_mean_mag': 'Gmag',
-                                'bp_rp': 'BP_RP'})
 
-    # Convert names to string
-    
-    df.gaiaDR3 = df.gaiaDR3.astype(str)
+    if flag_variable:
+        df = df.rename(columns={'phot_variable_flag': 'variable',
+                                'classlabel_espels': 'class',
+                                'activityindex_espcs': 'S',
+                                'activityindex_espcs_uncertainty': 'S_err'})
         
+    if flag_quasar:
+        df = df.rename(columns={'classprob_dsc_combmod_quasar': 'p_quasar'})
+
+    # Remove "Gaia DR" string in designation
+
+    df.designation = df.designation.str[9:]
+        
+    # Sort values
+
+    df = df.sort_values(by=['BP_RP'])
+        
+    # Convert names to string
+
+    df.gaiaDR3 = df.gaiaDR3.astype(str)
+
     # Reset index and return
 
     return df.reset_index(drop=True)

--- a/python/platosim/statistics.py
+++ b/python/platosim/statistics.py
@@ -259,60 +259,77 @@ def model_selection(AIC_j, BIC_j, method='BIC', show=False):
         wAIC_i.append(np.exp(-1/2*(AIC_j[i]-np.min(AIC_j))) / np.sum(np.exp(-1/2*dAIC_j)))
         pBIC_i.append(np.exp(-1/2*(BIC_j[i]-np.min(BIC_j))) / np.sum(np.exp(-1/2*dBIC_j)))
 
-    # Probability of model 1
-    p12 = wAIC_i[0] / (wAIC_i[0] + wAIC_i[1])
-    b12 = pBIC_i[0] / (pBIC_i[0] + pBIC_i[1])
+    # Probabilities
+    w12 = wAIC_i[0] / (wAIC_i[0] + wAIC_i[1]) * 100
+    p12 = pBIC_i[0] / (pBIC_i[0] + pBIC_i[1]) * 100
     if n == 3:
-        p13 = wAIC_i[0] / (wAIC_i[0] + wAIC_i[2])
-        b13 = pBIC_i[0] / (pBIC_i[0] + pBIC_i[2])
-        p23 = wAIC_i[1] / (wAIC_i[1] + wAIC_i[2])
-        b23 = pBIC_i[1] / (pBIC_i[1] + pBIC_i[2])
+        w13 = wAIC_i[0] / (wAIC_i[0] + wAIC_i[2]) * 100
+        p13 = pBIC_i[0] / (pBIC_i[0] + pBIC_i[2]) * 100
+        w23 = wAIC_i[1] / (wAIC_i[1] + wAIC_i[2]) * 100
+        p23 = pBIC_i[1] / (pBIC_i[1] + pBIC_i[2]) * 100
 
     # Find best model (in %)
-    p12 *= 100; p13 *= 100; p23 *= 100
-    b12 *= 100; b13 *= 100; b23 *= 100
     if n == 2:
+        # AIC probability
+        if w12 >= 50:
+            best_aic = 1
+        else:
+            best_aic = 2
+        # BIC probability
         if p12 >= 50:
-            best = 1
+            best_bic = 1
         else:
-            best = 2
+            best_bic = 2            
     elif n == 3:
-        if p12 >= 50 and p13 < 50:
-            best = 1
-        elif p23 >= 50 and p12 < 50:
-            best = 2
+        # AIC probability
+        if w12 >= 50 and w13 >= 50:
+            best_aic = 1
+        elif w23 >= 50 and w12 <= 50:
+            best_aic = 2
         else:
-            best = 3
+            best_aic = 3
+        # BIC probability
+        if p12 >= 50 and p13 >= 50:
+            best_bic = 1
+        elif p23 >= 50 and p12 <= 50:
+            best_bic = 2
+        else:
+            best_bic = 3
 
     # Show model output
     if show:
         print('\n------------------------------')
         print('Model comparison')
         for i in range(n):
-            print(f'AIC weight model {i+1}: {round(wAIC_i[i], 2)}')
-            print(f'BIC proba. model {i+1}: {round(pBIC_i[i], 2)}')
+            print(f'AIC weight model {i+1}: {round(wAIC_i[i], 3)}')
+            print(f'BIC proba. model {i+1}: {round(pBIC_i[i], 3)}')
             
         print('\nHeuristical likelihood')
-        print(f'w1/w2 : {round(wAIC_i[0]/wAIC_i[1], 3)}')
-        print(f'p1/p2 : {round(pBIC_i[0]/pBIC_i[1], 3)}')
+        print(f'w1/w2 : {round(wAIC_i[0]/wAIC_i[1], 4)}')
+        print(f'p1/p2 : {round(pBIC_i[0]/pBIC_i[1], 4)}')
         if n == 3:
-            print(f'w2/w3 : {round(wAIC_i[1]/wAIC_i[2], 3)}')
-            print(f'p2/p3 : {round(pBIC_i[1]/pBIC_i[2], 3)}')
-            print(f'w3/w1 : {round(wAIC_i[2]/wAIC_i[0], 3)}')
-            print(f'p3/p1 : {round(pBIC_i[2]/pBIC_i[0], 3)}')
+            print(f'w2/w3 : {round(wAIC_i[1]/wAIC_i[2], 4)}')
+            print(f'p2/p3 : {round(pBIC_i[1]/pBIC_i[2], 4)}')
+            print(f'w3/w1 : {round(wAIC_i[2]/wAIC_i[0], 4)}')
+            print(f'p3/p1 : {round(pBIC_i[2]/pBIC_i[0], 4)}')
             
         print('\nProbability in favour of model 1 over 2')
-        print(f'w1/(w1+w2) : {round(p12, 1)} %')
-        print(f'p1/(p1+p2) : {round(b12, 1)} %')
+        print(f'w1/(w1+w2) : {round(w12, 1)} %')
+        print(f'p1/(p1+p2) : {round(p12, 1)} %')
         if n == 3:
             print('\nProbability in favour of model 1 over 3')
-            print(f'w1/(w1+w3) : {round(p13, 1)} %')
-            print(f'p1/(p1+p3) : {round(b13, 1)} %')
+            print(f'w1/(w1+w3) : {round(w13, 1)} %')
+            print(f'p1/(p1+p3) : {round(p13, 1)} %')
             print('\nProbability in favour of model 2 over 3')
-            print(f'w2/(w2+w3) : {round(p23, 1)} %')
-            print(f'p2/(p2+p3) : {round(b23, 1)} %')
-        print(f'\nThe best model is: {best}')
+            print(f'w2/(w2+w3) : {round(w23, 1)} %')
+            print(f'p2/(p2+p3) : {round(p23, 1)} %\n')
+            
+        print(f'The best AIC model is: {best_aic}')
+        print(f'The best BIC model is: {best_bic}')
         print('------------------------------\n')
-        
-    return best
+
+    if method == 'AIC':
+        return best_aic
+    elif method == 'BIC':
+        return best_bic
     

--- a/python/platosim/utilities.py
+++ b/python/platosim/utilities.py
@@ -1398,7 +1398,121 @@ def copyInputYAML(field, odir):
 
 
 
+def copyVizierInputYAML(field, odir):
 
+    """Function to copy and adjust a yaml ready to launch.
+
+    Parameters
+    ----------
+    field : str
+        Observational PLATO field (e.g. SPF, NPF, LOPS2, LOPN1)
+    odir : str, pathlib object
+        Absolute output directory (pathlib object)
+
+    Notes
+    -----
+    The zero-point flux of a P=0 G2V-star [phot/s/m^2/nm] is 
+    converted to the PLATO passband since PlatoSim uses the
+    V magnitude as a standard.
+    """
+
+    # Get files names of YAML files
+    yaml_old = Path(os.getenv("PLATO_PROJECT_HOME") + "/inputfiles/inputfile.yaml")
+    yaml_new = odir / "inputfile_vizier.yaml"
+
+    # Copy YAML if it doesn't exist already
+    if not yaml_new.is_file():
+
+        shutil.copy(yaml_old, yaml_new)
+
+        # Find and replace a few strings:
+        with open(yaml_new, 'r') as file:
+            filedata = file.read()
+            filedata = filedata.replace('inputfiles/starcatalog.txt', field)
+            filedata = filedata.replace('1.00179e8       #', '0.73244782244e8 #')
+            filedata = filedata.replace('BackgroundValue:               -1',
+                                        'BackgroundValue:               0')
+            filedata = filedata.replace('IncludeCosmicsInSubField:        yes',
+                                        'IncludeCosmicsInSubField:        no')
+            filedata = filedata.replace('IncludeCosmicsInSmearingMap:     yes',
+                                        'IncludeCosmicsInSmearingMap:     no')
+            filedata = filedata.replace('IncludeCosmicsInBiasMap:         yes',
+                                        'IncludeCosmicsInBiasMap:         no')
+            filedata = filedata.replace('UseJitter:                       yes',
+                                        'UseJitter:                       no')
+            filedata = filedata.replace('IncludeAberrationCorrection:     yes',
+                                        'IncludeAberrationCorrection:     no')
+            filedata = filedata.replace('IncludePointLikeGhosts:          yes',
+                                        'IncludePointLikeGhosts:          no')
+            filedata = filedata.replace('IncludeChargeDiffusion:      yes',
+                                        'IncludeChargeDiffusion:      no')
+            filedata = filedata.replace('IncludeFlatfield:                yes',
+                                        'IncludeFlatfield:                no')
+            filedata = filedata.replace('IncludeDarkSignal:               yes',
+                                        'IncludeDarkSignal:               no')
+            filedata = filedata.replace('IncludeBFE:                      yes',
+                                        'IncludeBFE:                      no')
+            filedata = filedata.replace('IncludePhotonNoise:              yes',
+                                        'IncludePhotonNoise:              no')
+            filedata = filedata.replace('IncludeReadoutNoise:             yes',
+                                        'IncludeReadoutNoise:             no')
+            filedata = filedata.replace('IncludeCTIeffects:               yes',
+                                        'IncludeCTIeffects:               no')
+            filedata = filedata.replace('IncludeOpenShutterSmearing:      yes',
+                                        'IncludeOpenShutterSmearing:      no')
+            filedata = filedata.replace('IncludeQuantumEfficiency:        yes',
+                                        'IncludeQuantumEfficiency:        no')
+            filedata = filedata.replace('IncludeRelativeTransmissivity:   yes',
+                                        'IncludeRelativeTransmissivity:   no')
+            filedata = filedata.replace('IncludePolarization:             yes',
+                                        'IncludePolarization:             no')
+            filedata = filedata.replace('IncludeParticulateContamination: yes',
+                                        'IncludeParticulateContamination: no')
+            filedata = filedata.replace('IncludeMolecularContamination:   yes',
+                                        'IncludeMolecularContamination:   no')
+            filedata = filedata.replace('IncludeConvolution:              yes',
+                                        'IncludeConvolution:              no')
+            filedata = filedata.replace('IncludeFullWellSaturation:       yes',
+                                        'IncludeFullWellSaturation:       no')
+            filedata = filedata.replace('IncludeDigitalSaturation:        yes',
+                                        'IncludeDigitalSaturation:        no')
+            filedata = filedata.replace('IncludeQuantisation:             yes',
+                                        'IncludeQuantisation:             no')
+            filedata = filedata.replace('IncludeGainNonlinearity:         yes',
+                                        'IncludeGainNonlinearity:         no')
+            filedata = filedata.replace('WritePixelMaps:                  yes',
+                                        'WritePixelMaps:                  no')
+            filedata = filedata.replace('WriteBiasMaps:                   yes',
+                                        'WriteBiasMaps:                   no ')
+            filedata = filedata.replace('WriteSmearingMaps:               yes',
+                                        'WriteSmearingMaps:               no ')
+            filedata = filedata.replace('WriteFlatfieldMap:               yes',
+                                        'WriteFlatfieldMap:               no ')
+            filedata = filedata.replace('WriteThroughputMaps:             yes',
+                                        'WriteThroughputMaps:             no ')
+            filedata = filedata.replace('WriteTransmissionEfficiency:     yes',
+                                        'WriteTransmissionEfficiency:     no ')
+            filedata = filedata.replace('WriteBackgroundMap:              yes',
+                                        'WriteBackgroundMap:              no ')
+            filedata = filedata.replace('WriteCTI:                        yes',
+                                        'WriteCTI:                        no ')
+            filedata = filedata.replace('WriteACS:                        yes',
+                                        'WriteACS:                        no ')
+            filedata = filedata.replace('WriteTelescopeACS:               yes',
+                                        'WriteTelescopeACS:               no ')
+            filedata = filedata.replace('WriteStarCatalog:                yes',
+                                        'WriteStarCatalog:                no ')
+            filedata = filedata.replace('WriteGhostPositions:             yes',
+                                        'WriteGhostPositions:             no ')
+            filedata = filedata.replace('WriteCosmics:                    yes',
+                                        'WriteCosmics:                    no ')
+
+            # Write the file out again
+            with open(yaml_new, 'w') as file:
+                file.write(filedata)
+
+
+                
 #--------------------------------------------------------------#
 #        FUNCTIONS TO GENERATE THE PIC-VARSIM CATALOGS         #
 #--------------------------------------------------------------#


### PR DESCRIPTION
This update includes:
- A end-to-end PLATO FOV catalogue creation. This option is valid through `varsim --vizier` and now computes the 16 full-frame simulations needed determine how many cameras each target star is observed by. A final catalogue including all the Gaia DR3 information is saved. Before this used to be a separate step.
- Updates of `lightcurve.detrend` to make this method more robust for the Wotan model. It is now possible to bin the light curve before running Wotan, in order to speed up the computations. 