### PR TITLE
Depricated the use of the normal keyword in skyToPixelCoordinates...

### DIFF
--- a/python/platosim/referenceFrames.py
+++ b/python/platosim/referenceFrames.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import math
+import warnings
 
 # PlatoSim standard
 import h5py
@@ -1663,6 +1664,7 @@ def getCCDandPixelCoordinates(raStar, decStar, raPlatform, decPlatform, solarPan
         Nrows = CCD[ccdCode]["Nrows"]
         Ncols = CCD[ccdCode]["Ncols"]
         firstRow = CCD[ccdCode]["firstRow"]
+
         if (xCCDpix < 0)      or (yCCDpix < firstRow): continue
         if (xCCDpix >= Ncols) or (yCCDpix >= Nrows):   continue
 
@@ -1920,7 +1922,7 @@ def calculateSubfieldAroundCoordinates(subfieldSizeX, subfieldSizeY, raStar, dec
 
     # If the CCD code is None, the star does not fall on any ccd -> error
 
-    if ccdCode == None:
+    if ccdCode is None:
         return None, None, None
 
     # If the star does fall on a CCD, check if it's not too close to the edge for the subfield to
@@ -1947,7 +1949,7 @@ def calculateSubfieldAroundCoordinates(subfieldSizeX, subfieldSizeY, raStar, dec
 
 
 
-def skyToPixelCoordinates(sim, raStar, decStar, normal):
+def skyToPixelCoordinates(sim, raStar, decStar, normal=None):
 
     """From equatorial to pixel coordinates.
 
@@ -1973,8 +1975,6 @@ def skyToPixelCoordinates(sim, raStar, decStar, normal):
        Full width (# of columns) of the subfield [pix]
     subfieldSizeY : int
        Full height (# of rows) of the subfield [pix]
-    normal : bool
-       True for the normal camera configuration, False for the fast cameras
 
     Return
     ------
@@ -1987,17 +1987,19 @@ def skyToPixelCoordinates(sim, raStar, decStar, normal):
     yCCDpix : int 
         Y-coordinate (row) of star on the CCD [pix]
         If not on CCD: None
+    normal:
+        Is depricated and should no longer be used.
     """
 
     # Resolve which distortion model is used (if any)
-    
+
     if (sim["PSF/Model"] == "MappedFromFile"):
         includeFieldDistortion = True
         distortionCoefficients = None
         pathToPsfFile          = sim["PSF/MappedFromFile/Filename"]
         mappedDistortion       = True
     elif (sim["Camera/IncludeFieldDistortion"] == "yes"  or
-          sim["Camera/IncludeFieldDistortion"] == True):
+          sim["Camera/IncludeFieldDistortion"] is True):
         distortionCoefficients = sim["Camera/FieldDistortion/ConstantCoefficients"]
         pathToPsfFile          = None
         mappedDistortion       = False
@@ -2018,6 +2020,14 @@ def skyToPixelCoordinates(sim, raStar, decStar, normal):
     focalPlaneAngle       = np.deg2rad(float(sim["Camera/FocalPlaneOrientation/ConstantValue"]))
     azimuthTelescope      = np.deg2rad(float(sim["Telescope/AzimuthAngle"]))
     tiltTelescope         = np.deg2rad(float(sim["Telescope/TiltAngle"]))
+    normalCamera          = sim["Telescope/GroupID"] != "Fast"
+
+    # TODO: This should be removed in the next major release, together with the normal argument in this function.
+    if normal is not None:
+        warnings.warn("\nThe optional argument: normal is depricated is no longer used.\nThis value will from now on be derived from the Simulation argument in the function.", category=DeprecationWarning, stacklevel=2)
+        if not normal == normalCamera:
+            warnings.warn("\nThe value for normal is not consistent with the one specified in the Simulation argument.\nThis function will use the specified normal value, but keep in mind that this is different from the one defined in sim.", category=DeprecationWarning, stacklevel=2)
+            normalCamera = normal
 
     # Get the pixel coordinates on the CCD
 
@@ -2027,11 +2037,11 @@ def skyToPixelCoordinates(sim, raStar, decStar, normal):
                                                               tiltTelescope, azimuthTelescope,
                                                               focalPlaneAngle, focalLength,
                                                               pixelSize, includeFieldDistortion,
-                                                              normal, mappedDistortion,
+                                                              normalCamera, mappedDistortion,
                                                               distortionCoefficients, pathToPsfFile)
 
     # That's it!
-    
+
     return ccdCode, xCCDpixel, yCCDpixel
 
 
@@ -2142,7 +2152,7 @@ def pixelToSkyCoordinates(sim, ccdCode, xCCDpix, yCCDpix):
                                          focalPlaneAngle, focalLength)
 
     # That's it!
-    
+
     return ra, dec
 
 

--- a/python/platosim/simulation.py
+++ b/python/platosim/simulation.py
@@ -20,6 +20,7 @@ import ast
 import math
 import datetime
 import subprocess
+import warnings
 
 # PlatoSim standard
 import yaml
@@ -876,7 +877,7 @@ class Simulation(object):
 
 
     
-    def setSubfieldAroundPixelCoordinates(self, ccdCode, xCCDpixel, yCCDpixel, subfieldSizeX, subfieldSizeY, normal=True):
+    def setSubfieldAroundPixelCoordinates(self, ccdCode, xCCDpixel, yCCDpixel, subfieldSizeX, subfieldSizeY, normal=None):
 
         """Set the subfield around pixel coordinates.
         
@@ -966,7 +967,7 @@ class Simulation(object):
 
 
 
-    def setSubfieldAroundSkyCoordinates(self, raStar, decStar, subfieldSizeX, subfieldSizeY, normal=True):
+    def setSubfieldAroundSkyCoordinates(self, raStar, decStar, subfieldSizeX, subfieldSizeY, normal=None):
 
         """Set subfield around stellar coordinates
 
@@ -998,8 +999,9 @@ class Simulation(object):
             Width (i.e. number of columns) of the subiield [pixels]
         subfieldSizeY : int
             Height (i.e. number of rows) of the sub-field [pixels]
-        normal : bool
-            True for the normal camera configuration, False for the fast cameras
+        normal : 
+            Is depricated and should no longer be used.
+        
 
         Return
         ------
@@ -1014,7 +1016,7 @@ class Simulation(object):
         >>> raStar = np.deg2rad(90.0)                                      # [rad]
         >>> decStar = np.deg2rad(-48.0)                                    # [rad]
         >>> subfieldSizeX, subfieldSizeY = 8,8                             # [pixels]
-        >>> success = sim.setSubfieldAroundCoordinates(raStar, decStar, subfieldSizeX, subfieldSizeY, normal=True)
+        >>> success = sim.setSubfieldAroundCoordinates(raStar, decStar, subfieldSizeX, subfieldSizeY)
         >>> print(success)
         """
 
@@ -1044,6 +1046,16 @@ class Simulation(object):
         focalLength     = float(self["Camera/FocalLength/ConstantValue"]) * 1000.0  # [m] -> [mm]
         focalPlaneAngle = np.deg2rad(float(self["Camera/FocalPlaneOrientation/ConstantValue"]))
         pixelSize       = float(self["CCD/PixelSize"])
+        normalCamera    = self["Telescope/GroupID"] != "Fast"
+
+        # TODO: This should be removed in the next major release, together with the normal argument in this function.
+        if normal is not None:
+                warnings.warn("\nThe optional argument: normal is depricated is no longer used.\nThis value will from now on be derived from the value of Simulation[Telescope/GroupID].", category=DeprecationWarning, stacklevel=2)
+                if not normal == normalCamera:
+                    warnings.warn("\nThe value for the argument normal is not consistent with the one specified in the Simulation[Telescope/GroupID].\nThis function will use the specified normal value, but keep in mind that this is different from the one defined in the inputfile.", category=DeprecationWarning, stacklevel=2)
+                    normalCamera = normal
+                
+                
 
         # If the psf is MappedFromFile we need to include mapped field distortion
 
@@ -1076,7 +1088,7 @@ class Simulation(object):
                                                                     tiltTelescope, azimuthTelescope,
                                                                     focalPlaneAngle,
                                                                     focalLength, pixelSize,
-                                                                    includeFieldDistortion, normal,
+                                                                    includeFieldDistortion, normalCamera,
                                                                     mappedDistortion,
                                                                     distortionCoefficients,
                                                                     pathToPsfFile)
@@ -1091,21 +1103,24 @@ class Simulation(object):
         CCDOrientation   = rf.CCD[ccdCode]["angle"]
 
         # Fetch CCD code and pixel coordinates (account for field distortion if included)
-        
+
         infoCCD = rf.getCCDandPixelCoordinates(raStar, decStar,
                                                raPlatform, decPlatform, solarPanelOrientation,
                                                tiltTelescope, azimuthTelescope,
                                                focalPlaneAngle, focalLength, pixelSize,
-                                               includeFieldDistortion, normal,
+                                               includeFieldDistortion, normalCamera,
                                                mappedDistortion, distortionCoefficients,
                                                pathToPsfFile)
         ccdCode, xCCD, yCCD = infoCCD[0], infoCCD[1], infoCCD[2]
         
+        # F-Cam can drop the F suffix  for the CCD position (1F, 2F,.. -> 1, 2,..)
+        if not normalCamera:
+            ccdCode = ccdCode[0]
+
         # If we arrive here, there is no problem accommodating the entire sufield on the CCD
 
         self["Telescope/AzimuthAngle"] = np.rad2deg(azimuthTelescope)
         self["Telescope/TiltAngle"]    = np.rad2deg(tiltTelescope)
-
         self["CCD/Position"]      = str(ccdCode)
         self["CCD/OriginOffsetX"] = str(CCDOriginOffsetX)
         self["CCD/OriginOffsetY"] = str(CCDOriginOffsetY)
@@ -1221,7 +1236,7 @@ class Simulation(object):
 
         # Extract the needed information from the yaml input file
         # Note: groupIDs and ccdIDs start counting from 1...
-
+        print(self["CCD/Position"])
         if self["Telescope/GroupID"] == "Custom":
             azimuthAngle    = np.deg2rad(self["Telescope/AzimuthAngle"])
             tiltAngle       = np.deg2rad(self["Telescope/TiltAngle"])
@@ -1708,8 +1723,7 @@ class Simulation(object):
             subfieldIsOnCCD = self.setSubfieldAroundSkyCoordinates(raTargetsRad[i],
                                                                    decTargetsRad[i],
                                                                    subfieldSize,
-                                                                   subfieldSize,
-                                                                   normal=True)
+                                                                   subfieldSize)
             if subfieldIsOnCCD:
                 xFP, yFP = rf.skyToFocalPlaneCoordinates(raTargetsRad[i],
                                                          decTargetsRad[i],
@@ -1797,7 +1811,7 @@ class Simulation(object):
         for i in range(len(ra)):
 
             subfieldIsOnCCD = self.setSubfieldAroundSkyCoordinates(raTargetsRad[i], decTargetsRad[i],
-                                                                   6, 6, normal=True)
+                                                                   6, 6)
             if subfieldIsOnCCD:
 
                 # Fetch CCD code and pixel coordinates (account for field distortion in included)


### PR DESCRIPTION
... in referenceFrames.py.

This value will from now on be infered form the simulation object that is given as argument.

It is (for now) still possible to use the keyword, but a warning will be generated to the user. If the keyword does not match the value of the Simulation object another warning will be given and the method will use the value as given from the normal keyword.