### PR TITLE
Update of varsim.py and simfile.py

### DIFF
--- a/python/platosim/platonium/varsim.py
+++ b/python/platosim/platonium/varsim.py
@@ -181,15 +181,28 @@ class VarSim(object):
         self.ofile  = args.ofile
         self.starID = None
         
-        # Star and planet mode
-        self.star   = args.star
-        self.binary = args.binary
-        self.planet = args.planet
-        self.star_params   = args.star_params
-        self.planet_params = args.planet_params
+        # Star mode
+        self.star        = args.star
+        self.star_params = args.star_params
 
+        # Binary mode
+        self.binary = args.binary
+
+        # Planet mode
+        self.planet = args.planet
+        self.planet_params = args.planet_params
         #self.phase_curve = args.phase_curve TODO
 
+        # Limb darkening model
+        self.ldms = ['linear', 'quadratic', 'squareroot', 'power2']
+        if args.ldm is None:
+            self.ldm = 'power2'
+        elif args.ldm not in self.ldms:
+            errorcode('error', f'Limb Darkening model "{args.ldm}" is not available!' +
+                      f'\nUse either: {self.ldms}')
+        else:
+            self.ldm = args.ldm
+            
         # Use Kallinger2014 by default
         if args.gran == None: 
             args.gran = 'Kallinger2014'
@@ -1609,24 +1622,41 @@ class VarSim(object):
         # Create the limb darkening profiles
         ps = sc.create_profiles()
 
-        # Estimate quadratic law coefficients
-        # Take care of occations when LDTk fails
+        # Determine law coefficients
+        # NOTE we only allow 2-term models
         try:
-            u, _ = ps.coeffs_qd(do_mc=True)
+            if self.ldm == 'linear':
+                u, _ = ps.coeffs_ln(do_mc=True)
+            elif self.ldm == 'quadratic':
+                u, _ = ps.coeffs_qd(do_mc=True)
+            elif self.ldm == 'squareroot':
+                u, _ = ps.coeffs_sq(do_mc=True)
+            elif self.ldm == 'power2':
+                u, _ = ps.coeffs_p2(do_mc=True)
         except:
-            self.ldc = [0.430, 0.170]
+            if self.ldm == 'linear':
+                self.ldc = [0.570]
+            elif self.ldm == 'quadratic':
+                self.ldc = [0.470, 0.153]
+            elif self.ldm == 'squareroot':
+                self.ldc = [0.334, 0.364]
+            elif self.ldm == 'power2':
+                self.ldc = [0.670, 0.759]
             errorcode('warning', 'LD coefficients failed for ' +
                       f'(Teff, logg, Z) = ({self.Teff}, {self.logg}, {self.Z}')
         else:
             self.ldc = u[0]
 
-        # Show parameters
-        if self.verbose > 1:
-            print(f"LD coefficients        : {self.ldc[0]:.3f}, {self.ldc[1]:.3f}")
-
         # Store parameters
-        self.df['u1'] = self.ldc[0]
-        self.df['u2'] = self.ldc[1]
+        if len(self.ldc) == 1:
+            self.df['u1'] = self.ldc[0]
+            if self.verbose > 1:
+                print(f"LD {self.ldm} coefficients : {self.ldc[0]:.3f}")
+        else:
+            self.df['u1'] = self.ldc[0]
+            self.df['u2'] = self.ldc[1]
+            if self.verbose > 1:
+                print(f"LD {self.ldm} coefficients : {self.ldc[0]:.3f}, {self.ldc[1]:.3f}")
 
             
     def planet_model(self):
@@ -1851,15 +1881,9 @@ class VarSim(object):
         Here we make sure to use consistent reference time unit.
         """
 
-        # Limb darkening model options:
-        if args.ldm:
-            limbDarkModel = args.lmd
-        else:
-            limbDarkModel = 'quadratic'
-
         # Initialize batman model
         batman_params = batman.TransitParams()
-        batman_params.limb_dark = limbDarkModel
+        batman_params.limb_dark = self.ldm
         batman_params.u   = self.ldc
         batman_params.t0  = self.t0.to('d').value
         batman_params.per = self.P.to('d').value
@@ -1870,11 +1894,11 @@ class VarSim(object):
         batman_params.rp  = (self.Rp.to('m')/self.R.to('m')).value
 
         # Model parameters for eclipse
-        #params.fp          = 0.001
-        #params.t_secondary = 0.5
+        #batman_params.fp          = 0.001
+        #batman_params.t_secondary = 0.5
         
         # Initializes transit model and extract light curve [ppm]
-        model = batman.TransitModel(batman_params, self.time.value)
+        model = batman.TransitModel(batman_params, self.time.value) #, transittype='secondary')
         self.lc['tran'] = (model.light_curve(batman_params) - 1) * 1e6
 
         # True anomaly at each time: This will be used in our custom models later
@@ -2822,8 +2846,8 @@ planet_group.add_argument('--planet', metavar='NAME', type=str, help='Benchmark 
 planet_group.add_argument('--planet_params', action='append', type=float, nargs=7, metavar=('t0', 'P', 'e', 'i', 'w', 'Rp', 'Mp'),
                           help='Planet model parameters (check --notes)')
 #planet_group.add_argument('--phase_curve', action='store_true', help='Flag orbital phase curve (occultation, beaming, ellipsoidal)')
-planet_group.add_argument('--ldm',   metavar='MODEL', type=str, help='Limb darkening model [quadratic]')
-planet_group.add_argument('--moon', metavar='NAME', type=str, help='Benchmark moon (check --notes)')
+planet_group.add_argument('--ldm',  metavar='MODEL', type=str, help='Limb darkening model [power2, squareroot, quadratic, linear]')
+planet_group.add_argument('--moon', metavar='NAME',  type=str, help='Benchmark moon (check --notes)')
 
 
 mode_group = parser.add_argument_group('DISTRIBUTION MODES')

--- a/python/platosim/simfile.py
+++ b/python/platosim/simfile.py
@@ -465,24 +465,6 @@ class SimFile (object):
 
 
     
-    # def getIRNU(self):
-
-    #     """Get the Intra-pixel Response Non-Uniformity map from the HDF5 file.
-
-    #     To rebin the IRNU to the PRNU:
-
-    #     >>> Nrows, Ncols = 100, 100      # size in pixels of the subfield
-    #     >>> NsubPixels = 16              # 16^2 subpixels in 1 pixel
-    #     >>> assert(IRNU.shape == (Nrows*NsubPixels, Ncols*NsubPixels))
-    #     >>> PRNU = IRNU.reshape(Nrows, NsubPixels, Ncols, NsubPixels).sum(axis=3).sum(axis=1)
-    #     """
-
-    #     return self.getMap("IRNU", imageNr=0)
-
-
-
-
-    
     def getBackground(self):
 
         """Get the sky background map [photons/pixel/exposure]
@@ -554,7 +536,7 @@ class SimFile (object):
         """Get the pixel image.
         """
 
-        return self.getMap("Images", imageNr=imageNr).astype(np.int32)
+        return self.getMap("Images", imageNr=imageNr)
 
         
 
@@ -620,7 +602,7 @@ class SimFile (object):
 
         # Extract the imagette
 
-        return image[rowBegin:rowEnd, columnBegin:columnEnd].astype(np.int32)
+        return image[rowBegin:rowEnd, columnBegin:columnEnd]
 
 
     


### PR DESCRIPTION
Changes
- We included several new limb darkening (LD) laws into `varsim.py`. The LD coefficients are still calculated by the software LDTk, but:
  - i) the default model now has been changed to the `power-2` law instead of the `quadratic` law. This was done by request and recommendation of Magali and Pierre Maxted. 
  - ii) We have added more LD laws to be used: `linear`, `quadratic`, `squareroot`, and `power2`.

Bugfixes
- We made a change to `simfile.getImage()` and `simfile.getImagette()` forcing that the array returned was of unit `int32`. However, this lead to a failure of the validation tests. We revert this change and will look at the issue in the future. For now `simfile.getImage()` returns units of `int16` which is not desired since no operations leading to negative numbers can be done (negative number overshoot to be (65353 - Number). 