### PR TITLE
Fixing issue #1087 transfer time duration

### DIFF
--- a/inputfiles/inputfile.yaml
+++ b/inputfiles/inputfile.yaml
@@ -31,10 +31,10 @@ Sky:
       TrailLength:                   [0, 15]         # Boundaries of uniform distribution for the length of the cosmic trails [pixels]
       Intensity:                     [2500., 2000., 30.] # Location, scale>0, and shape of the skew-Normal distribution for the total number of e- in a cosmic hit [e-]
     StrayLight:
-      IncludeStrayLight:               True
-      FilePath:                        inputfiles/Plato_straylight_example_index_2574.csv
-      PstRadiancePath:                 inputfiles/pst.hdf5
-      Time0:                           20260718T015614
+      IncludeStrayLight:             True            # Include stray light [True, False]
+      FilePath:                      inputfiles/Plato_straylight_example_index_2574.csv
+      PstRadiancePath:               inputfiles/pst.hdf5
+      Time0:                         20260718T015614
 
 
 Platform:

--- a/source/Simulation.cpp
+++ b/source/Simulation.cpp
@@ -346,28 +346,25 @@ pair<double, double> Simulation::configureReadoutTime(ConfigurationParameters &c
                 throw ConfigurationException("Simulation: Unknown readout mode specification in configuration file");
         }
 
-        double serialTransferTime = configParams.getDouble("CCD/SerialTransferTime") * 1E-9;			  // [ns] -> [s]
-        double parallelTransferTime = configParams.getDouble("CCD/ParallelTransferTime") * 1E-6;		  // [µs] -> [s]
+        double serialTransferTime = configParams.getDouble("CCD/SerialTransferTime") * 1E-9;		  // [ns] -> [s]
+        double parallelTransferTime = configParams.getDouble("CCD/ParallelTransferTime") * 1E-6;	  // [µs] -> [s]
         double parallelTransferTimeFast = configParams.getDouble("CCD/ParallelTransferTimeFast") * 1E-6;  // [µs] -> [s]
 
 
-
-    int numColumnsBiasMap =  configParams.getInteger("SubField/NumBiasPrescanColumns");     // [pixels]
-    int numRowsSmearingMap = configParams.getInteger("SubField/NumSmearingOverscanRows");   // [pixels]
-
+	int numColumnsBiasMap =  configParams.getInteger("SubField/NumBiasPrescanColumns");     // [pixels]
+	int numBiasPrescanRows = configParams.getInteger("SubField/NumBiasPrescanRows");        // [pixels]
+	int numRowsSmearingMap = configParams.getInteger("SubField/NumSmearingOverscanRows");   // [pixels]
 
 
         double readoutTimeBeforeNextExposure, readoutTimeDuringNextExposure;
-
-
 
         // Both detector halves are read out simultaneously
         // -> columns read out by the FEE:
         //              - half of the CCD
         //              - serial pre-scan
-        //              - (serial over-scan)
+        //              - Parallel pre-scan
 
-        int numColumnsReadout = numColumns / 2 + numColumnsBiasMap; // + numRowsSerialOverScan
+        int numColumnsReadout = numColumns / 2 + numColumnsBiasMap + numBiasPrescanRows;
 
         // How many rows will be actually read out by the FEE?
         //      - nominal mode: image area + parallel over-scan


### PR DESCRIPTION
Bugfixes
- This PR "Fixes #1087". The transfer time duration has been updated to include now also the bias parallel prescan of extra 15 pixels.

Updates
- Added consistent indentation to straylight block in YAML file.  
