### PR TITLE
Removed duplicate call to applyThroughputEfficiency for Analytic

### DIFF
--- a/source/DetectorWithAnalyticGaussianPSF.cpp
+++ b/source/DetectorWithAnalyticGaussianPSF.cpp
@@ -389,12 +389,6 @@ void DetectorWithAnalyticGaussianPSF::integrateLight(int exposureNr, double star
 
     applyThroughputEfficiency();
 
-    // Apply throughput efficiency on the pixel map.
-    // This takes into account the QE, vignetting, polarisation, and particulate & molecular contamination.
-    // PixelMap units change from [photons] to [electrons]
-
-    applyThroughputEfficiency();
-
     // Apply the charge injection which will mitigate the CTI. The injection happens in electrons,
     // so the throughput efficiency should already have been applied. The injected charges do feel the PRNU,
     // so applying the flatfied should happen afterwards.


### PR DESCRIPTION
Gaussion PFS.

See issue #1191.